### PR TITLE
Test-suite skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,35 @@
-# Compiled class file
-*.class
+# Eclipse
+.project
+.classpath
+.settings/
+bin/
 
-# Log file
-*.log
+# IntelliJ
+.idea
+*.ipr
+*.iml
+*.iws
 
-# BlueJ files
-*.ctxt
+# NetBeans
+nb-configuration.xml
 
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
+# Visual Studio Code
+.vscode
 
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
+# OSX
+.DS_Store
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
+# Vim
+*.swp
+*.swo
+
+# patch
+*.orig
+*.rej
+
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+release.properties

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # eap-microprofile-test-suite
  a small standalone test suite for MicroProfile on WF/EAP
+
+## Run the testsuite
+```
+mvn clean verify -Darquillian.deploymentExportPath=target/deployments/
+```
+
+## Export testing deployments
+```
+mvn clean verify -Darquillian.deploymentExportPath=target/deployments/
+```
+
+## Run one module against custom build
+```
+mvn clean verify -pl microprofile-health -Djboss.home=/Users/rsvoboda/Downloads/wildfly-18.0.0.Final
+```
+
+## Run one module against running server
+```
+mvn clean verify -pl microprofile-health
+```
+Please note `allowConnectingToRunningServer` property in `arquillian.xml`.

--- a/arquillian.xml
+++ b/arquillian.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="jboss" default="true" >
+        <configuration>
+            <property name="jbossHome">${jboss.home}</property>
+            <property name="javaVmArguments">-server -Xms64m -Xmx512m</property>
+            <property name="serverConfig">standalone.xml</property>
+            <property name="managementAddress">127.0.0.1</property>
+            <property name="managementPort">9990</property>
+            <property name="waitForPorts">9990</property>
+            <property name="waitForPortsTimeoutInSeconds">10</property>
+            <property name="allowConnectingToRunningServer">true</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+      <groupId>org.jboss.eap.qe</groupId>
+      <artifactId>microprofile-test-suite</artifactId>
+      <version>1.0.0.Final-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>microprofile-health</artifactId>
+
+    <!--Port of https://github.com/rhoar-qe/thorntail-test-suite/tree/master/microprofile/microprofile-health-check-2.0-->
+
+</project>

--- a/microprofile-health/src/main/java/org/jboss/eap/qe/microprofile/health/BothHealthCheck.java
+++ b/microprofile-health/src/main/java/org/jboss/eap/qe/microprofile/health/BothHealthCheck.java
@@ -1,0 +1,15 @@
+package org.jboss.eap.qe.microprofile.health;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+import org.eclipse.microprofile.health.Readiness;
+
+@Liveness
+@Readiness
+public class BothHealthCheck implements HealthCheck {
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("both").up().withData("key", "value").build();
+    }
+}

--- a/microprofile-health/src/main/java/org/jboss/eap/qe/microprofile/health/DeprecatedHealthCheck.java
+++ b/microprofile-health/src/main/java/org/jboss/eap/qe/microprofile/health/DeprecatedHealthCheck.java
@@ -1,0 +1,14 @@
+package org.jboss.eap.qe.microprofile.health;
+
+import org.eclipse.microprofile.health.Health;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+@Health
+@SuppressWarnings("deprecation") // @Health is deprecated, but should work in v20
+public class DeprecatedHealthCheck implements HealthCheck {
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("deprecated-health").up().withData("key", "value").build();
+    }
+}

--- a/microprofile-health/src/main/java/org/jboss/eap/qe/microprofile/health/LivenessHealthCheck.java
+++ b/microprofile-health/src/main/java/org/jboss/eap/qe/microprofile/health/LivenessHealthCheck.java
@@ -1,0 +1,13 @@
+package org.jboss.eap.qe.microprofile.health;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+
+@Liveness
+public class LivenessHealthCheck implements HealthCheck {
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("live").up().withData("key", "value").build();
+    }
+}

--- a/microprofile-health/src/main/java/org/jboss/eap/qe/microprofile/health/ReadinessHealthCheck.java
+++ b/microprofile-health/src/main/java/org/jboss/eap/qe/microprofile/health/ReadinessHealthCheck.java
@@ -1,0 +1,13 @@
+package org.jboss.eap.qe.microprofile.health;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+
+@Readiness
+public class ReadinessHealthCheck implements HealthCheck {
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("ready").up().withData("key", "value").build();
+    }
+}

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MicroProfileHealth21Test.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MicroProfileHealth21Test.java
@@ -1,0 +1,81 @@
+package org.jboss.eap.qe.microprofile.health;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.Matchers.*;
+
+@RunAsClient
+@RunWith(Arquillian.class)
+public class MicroProfileHealth21Test {
+
+    @ContainerResource
+    ManagementClient managementClient;
+
+    String healthURL;
+    @Before
+    public void composeHealthEndpointURL() {
+        healthURL = "http://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort() + "/health";
+    }
+
+    @Deployment(testable = false)
+    public static Archive<?> deployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileHealthCheckDeprecatedTest.war")
+                .addClasses(DeprecatedHealthCheck.class, BothHealthCheck.class, LivenessHealthCheck.class, ReadinessHealthCheck.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return war;
+    }
+
+    @Test
+    public void testHealthEndpoint() {
+        RestAssured.when().get(healthURL).then()
+                .contentType(ContentType.JSON)
+                .header("Content-Type", containsString("application/json"))
+                .body("status", is("UP"),
+                        "checks", hasSize(5), // BothHealthCheck contains both annotations: @Liveness and @Readiness
+                        "checks.status", hasItems("UP"),
+                        "checks.status", not(hasItems("DOWN")),
+                        "checks.name", containsInAnyOrder("deprecated-health", "both", "live", "ready", "both"),
+                        "checks.data", hasSize(5),
+                        "checks.data[0].key", is("value"),
+                        "checks.data[0..4].key", hasItems("value"));
+    }
+
+    @Test
+    public void testLivenessEndpoint() {
+        RestAssured.when().get(healthURL + "/live").then()
+                .contentType(ContentType.JSON)
+                .header("Content-Type", containsString("application/json"))
+                .body("status", is("UP"),
+                        "checks", hasSize(2),
+                        "checks.status", hasItems("UP"),
+                        "checks.name", containsInAnyOrder("both", "live"),
+                        "checks.data", hasSize(2),
+                        "checks.data[0..1].key", hasItems("value"));
+    }
+    @Test
+    public void testReadinessEndpoint() {
+        RestAssured.when().get(healthURL + "/ready").then()
+                .contentType(ContentType.JSON)
+                .header("Content-Type", containsString("application/json"))
+                .body("status", is("UP"),
+                        "checks", hasSize(2),
+                        "checks.status", hasItems("UP"),
+                        "checks.name", containsInAnyOrder("both", "ready"),
+                        "checks.data", hasSize(2),
+                        "checks.data[0..1].key", hasItems("value"));
+    }
+
+}

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MicroProfileHealthDeprecatedTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MicroProfileHealthDeprecatedTest.java
@@ -1,0 +1,60 @@
+package org.jboss.eap.qe.microprofile.health;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.Matchers.*;
+
+@RunAsClient
+@RunWith(Arquillian.class)
+public class MicroProfileHealthDeprecatedTest {
+
+    @ContainerResource
+    ManagementClient managementClient;
+
+    @Deployment(testable = false)
+    public static Archive<?> deployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileHealthCheckDeprecatedTest.war")
+                .addClasses(DeprecatedHealthCheck.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return war;
+    }
+
+    @Test
+    public void testDeprecatedHealthCheck() {
+        final String healthURL = "http://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort() + "/health";
+
+        RestAssured.when().get(healthURL).then()
+                .contentType(ContentType.JSON)
+                .header("Content-Type", containsString("application/json"))
+                .body("status", is("UP"),
+                        "checks.status", containsInAnyOrder("UP"),
+                        "checks.name", containsInAnyOrder("deprecated-health"));
+
+        RestAssured.when().get(healthURL + "/live").then()
+                .contentType(ContentType.JSON)
+                .header("Content-Type", containsString("application/json"))
+                .body("status", is("UP"),
+                        "checks.status", is(empty()),
+                        "checks.name", is(empty()));
+
+        RestAssured.when().get(healthURL + "/ready").then()
+                .contentType(ContentType.JSON)
+                .header("Content-Type", containsString("application/json"))
+                .body("status", is("UP"),
+                        "checks.status", is(empty()),
+                        "checks.name", is(empty()));
+    }
+
+}

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+      <groupId>org.jboss.eap.qe</groupId>
+      <artifactId>microprofile-test-suite</artifactId>
+      <version>1.0.0.Final-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>microprofile-metrics</artifactId>
+    
+    <dependencies>
+
+    </dependencies>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,152 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>36</version>
+    </parent>
+
+    <groupId>org.jboss.eap.qe</groupId>
+    <artifactId>microprofile-test-suite</artifactId>
+    <version>1.0.0.Final-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>Test suite for MicroProfile on WF/EAP</name>
+
+    <modules>
+        <module>microprofile-health</module>
+        <module>microprofile-metrics</module>
+    </modules>
+
+    <properties>
+        <jboss.home>IF-NOT-DEFINED-WILDFLY-WILL-BE-DOWNLOADED-UNZIPPED-AND-USED-AUTOMATICALLY</jboss.home>
+        <maven.test.redirectTestOutputToFile>false</maven.test.redirectTestOutputToFile>
+
+        <version.io.rest-assured>4.1.2</version.io.rest-assured>
+        <version.junit.vintage>5.5.2</version.junit.vintage>
+<!--        <version.org.eclipse.microprofile>2.0.1</version.org.eclipse.microprofile> -->
+        <version.org.eclipse.microprofile>3.0</version.org.eclipse.microprofile>
+        <version.org.jboss.arquillian>1.5.0.Final</version.org.jboss.arquillian>
+        <version.org.jboss.wildfly.dist>18.0.0.Final</version.org.jboss.wildfly.dist>
+        <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>${version.org.eclipse.microprofile}</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${version.junit.vintage}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${version.io.rest-assured}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <version>${version.org.jboss.arquillian}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-managed</artifactId>
+            <version>${version.org.wildfly.arquillian}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-dist</artifactId>
+            <version>${version.org.jboss.wildfly.dist}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <jboss.home>${jboss.home}</jboss.home>
+                        <arquillian.xml>${maven.multiModuleProjectDirectory}/arquillian.xml</arquillian.xml>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>download-wildfly</id>
+            <activation>
+                <property><name>!jboss.home</name></property>
+            </activation>
+            <properties>
+                <jboss.home>${basedir}/target/jboss-as</jboss.home>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-jboss-as</id>
+                                <phase>generate-test-resources</phase>
+                                <goals><goal>unpack</goal></goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.wildfly</groupId>
+                                            <artifactId>wildfly-dist</artifactId>
+                                            <version>${version.org.jboss.wildfly.dist}</version>
+                                            <type>zip</type>
+                                            <overWrite>true</overWrite>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>rename-unpacked-jboss-as</id>
+                                <phase>process-test-resources</phase>
+                                <goals><goal>run</goal></goals>
+                                <configuration>
+                                    <target>
+                                        <delete dir="${project.build.directory}/jboss-as"/>
+                                        <move todir="${project.build.directory}/jboss-as">
+                                            <fileset dir="${project.build.directory}">
+                                                <include name="jboss*/**/*"/>
+                                                <include name="wildfly*/**/*"/>
+                                            </fileset>
+                                            <cutdirsmapper dirs="1"/>
+                                        </move>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <maven.test.redirectTestOutputToFile>false</maven.test.redirectTestOutputToFile>
 
         <version.io.rest-assured>4.1.2</version.io.rest-assured>
-        <version.junit.vintage>5.5.2</version.junit.vintage>
+        <version.junit>4.12</version.junit>
 <!--        <version.org.eclipse.microprofile>2.0.1</version.org.eclipse.microprofile> -->
         <version.org.eclipse.microprofile>3.0</version.org.eclipse.microprofile>
         <version.org.jboss.arquillian>1.5.0.Final</version.org.jboss.arquillian>
@@ -42,9 +42,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${version.junit.vintage}</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Test-suite skeleton
 - usage described in README
 - downloads WF distribution if `jboss.home` is not defined
 - ARQ can connect to running server to speed up tests development turnaround
 - uses RestAssured
 - example module for MP Health