### PR TITLE
Add tooling for starting docker containers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <name>Test suite for MicroProfile on WF/EAP</name>
 
     <modules>
+        <module>tooling-docker</module>
         <module>microprofile-health</module>
         <module>microprofile-metrics</module>
     </modules>
@@ -31,6 +32,7 @@
         <version.org.jboss.arquillian>1.5.0.Final</version.org.jboss.arquillian>
         <version.org.jboss.wildfly.dist>18.0.0.Final</version.org.jboss.wildfly.dist>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
+        <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
     </properties>
 
     <dependencies>
@@ -45,7 +47,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${version.junit}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>
@@ -69,6 +70,12 @@
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-dist</artifactId>
             <version>${version.org.jboss.wildfly.dist}</version>
+        </dependency>
+        <!-- used in tooling-docker module for ANSI escape characters output from docker container  -->
+        <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+            <version>${version.org.fusesource.jansi}</version>
         </dependency>
     </dependencies>
 

--- a/tooling-docker/pom.xml
+++ b/tooling-docker/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.eap.qe</groupId>
+        <artifactId>microprofile-test-suite</artifactId>
+        <version>1.0.0.Final-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>tooling-docker</artifactId>
+
+</project>

--- a/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/ContainerReadyCondition.java
+++ b/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/ContainerReadyCondition.java
@@ -1,0 +1,31 @@
+package org.jboss.eap.qe.ts.common.docker;
+
+import java.util.concurrent.CompletableFuture;
+
+@FunctionalInterface
+public interface ContainerReadyCondition {
+
+    /**
+     * Waits until isReady() returns true otherwise exception is thrown.
+     * <p>
+     * Usually this is checked by checking exposed port or calling health check inside docker container.
+     */
+    default void waitUntilReady(long timeoutInMillis) throws Exception {
+        long startTime = System.currentTimeMillis();
+        while (!(new CompletableFuture().supplyAsync(() -> isReady())).get()) {
+            if (System.currentTimeMillis() - startTime > timeoutInMillis) {
+                throw new Exception("Container was not ready in timeout : " + timeoutInMillis + " ms");
+            }
+        }
+    }
+
+    /**
+     * Returns true if container is ready. Usually this checked by calling health check on running container
+     * or checking opened ports.
+     * <p>
+     * Note that this method is expected to be short running (<1 second)
+     *
+     * @return true if container is ready, otherwise false
+     */
+    boolean isReady();
+}

--- a/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/Docker.java
+++ b/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/Docker.java
@@ -1,0 +1,204 @@
+package org.jboss.eap.qe.ts.common.docker;
+
+import org.fusesource.jansi.Ansi;
+import org.junit.rules.ExternalResource;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility class for starting docker containers. This class allows to start any docker container.
+ * <p>
+ * Intended to be used as a JUnit @ClassRule. Example of usage - see org.jboss.eap.qe.ts.common.docker.DockerTest test
+ */
+public class Docker extends ExternalResource {
+
+    private String uuid;
+    private String name;
+    private String image;
+    private List<String> ports = new ArrayList<>();
+    private Map<String, String> environmentVariables = new HashMap<>();
+    private List<String> commandArguments = new ArrayList<>();
+    private ContainerReadyCondition containerReadyCondition;
+    private long containerReadyTimeout;
+    private final ExecutorService outputPrinter = Executors.newSingleThreadExecutor();
+
+    private Docker() {
+    } // avoid instantiation, use Builder
+
+    protected void start() throws Exception {
+        List<String> cmd = new ArrayList<>();
+
+        cmd.add("docker");
+        cmd.add("run");
+        cmd.add("--name");
+        cmd.add(uuid);
+
+        for (String port : ports) {
+            cmd.add("-p");
+            cmd.add(port);
+        }
+
+        for (Map.Entry<String, String> envVar : environmentVariables.entrySet()) {
+            cmd.add("-e");
+            cmd.add(envVar.getKey() + "=" + envVar.getValue());
+        }
+
+        cmd.add(image);
+
+        cmd.addAll(commandArguments);
+
+        System.out.println(Ansi.ansi().reset().a("Starting container ").fgCyan().a(name).reset()
+                .a(" with ID ").fgYellow().a(uuid).reset());
+
+        Process dockerRunProcess = new ProcessBuilder()
+                .redirectErrorStream(true)
+                .command(cmd)
+                .start();
+
+        outputPrinter.execute(() -> {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(dockerRunProcess.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    System.out.println(Ansi.ansi().fgCyan().a(name).reset().a("> ").a(line));
+                }
+            } catch (IOException ignored) {
+                // ignore as any stop of docker container breaks the reader stream
+                // note that shutdown of docker would be already logged
+            }
+        });
+
+        containerReadyCondition.waitUntilReady(containerReadyTimeout);
+    }
+
+    protected void stop() throws Exception {
+        System.out.println(Ansi.ansi().reset().a("Stopping container ").fgCyan().a(name).reset()
+                .a(" with ID ").fgYellow().a(uuid).reset());
+
+        new ProcessBuilder()
+                .command("docker", "stop", uuid)
+                .start()
+                .waitFor(10, TimeUnit.SECONDS);
+
+        outputPrinter.shutdown();
+        outputPrinter.awaitTermination(10, TimeUnit.SECONDS);
+
+        new ProcessBuilder()
+                .command("docker", "rm", uuid)
+                .start()
+                .waitFor(10, TimeUnit.SECONDS);
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        start();
+    }
+
+    @Override
+    protected void after() {
+        try {
+            stop();
+        } catch (Exception e) {
+            System.out.println(Ansi.ansi().reset().a("Failed stopping container ").fgCyan().a(name).reset()
+                    .a(" with ID ").fgYellow().a(uuid).reset());
+        }
+    }
+
+    public static class Builder {
+        private String uuid;
+        private String name;
+        private String image;
+        private List<String> ports = new ArrayList<>();
+        private Map<String, String> environmentVariables = new HashMap<>();
+        private List<String> commandArguments = new ArrayList<>();
+        private long containerReadyTimeoutInMillis = 60_000; // 1 minutes
+
+        // by default - do not make any check
+        private ContainerReadyCondition containerReadyCondition = () -> true;
+
+        public Builder(String name, String image) {
+            this.uuid = UUID.randomUUID().toString();
+            this.name = name;
+            this.image = image;
+        }
+
+        /**
+         * Timeout in millis to wait until container is ready/starts
+         *
+         * @param timeoutInMillis timeout in millis         *
+         */
+        public Builder setContainerReadyTimeout(long timeoutInMillis) {
+            this.containerReadyTimeoutInMillis = timeoutInMillis;
+            return this;
+        }
+
+        /**
+         * Adds port mapping exposed by docker container. For example "8080:80" maps
+         * port 80 in the container to port 8080 on the Docker host.
+         *
+         * @param portMapping port mapping as defined by docker command, for exampple "8080:80" or "8080:80/tcp"
+         */
+        public Builder wihtPortMapping(String portMapping) {
+            this.ports.add(portMapping);
+            return this;
+        }
+
+        /**
+         * Adds environment variable passed to docker container
+         *
+         * @param key   name of environment variable
+         * @param value value of environment variable
+         */
+        public Builder withEnvVar(String key, String value) {
+            environmentVariables.put(key, value);
+            return this;
+        }
+
+        /**
+         * Adds parameters into starting docker command
+         *
+         * @param commandArgument additional docker parameters
+         */
+        public Builder withCmdArg(String commandArgument) {
+            commandArguments.add(commandArgument);
+            return this;
+        }
+
+        /**
+         * Sets condition/check returning true if container is ready.
+         *
+         * @param containerReadyCondition condition returning true when container is ready, false otherwise
+         */
+        public Builder setContainerReadyCondition(ContainerReadyCondition containerReadyCondition) {
+            this.containerReadyCondition = containerReadyCondition;
+            return this;
+        }
+
+        /**
+         * Builds instance of Docker class.
+         *
+         * @return build Docker instance
+         */
+        public Docker build() {
+            Docker docker = new Docker();
+            docker.uuid = this.uuid;
+            docker.name = this.name;
+            docker.image = this.image;
+            docker.ports = this.ports;
+            docker.environmentVariables = this.environmentVariables;
+            docker.commandArguments = this.commandArguments;
+            docker.containerReadyCondition = containerReadyCondition;
+            docker.containerReadyTimeout = containerReadyTimeoutInMillis;
+            return docker;
+        }
+    }
+}

--- a/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/DockerContainers.java
+++ b/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/DockerContainers.java
@@ -1,0 +1,41 @@
+package org.jboss.eap.qe.ts.common.docker;
+
+import java.io.IOException;
+import java.net.Socket;
+
+/**
+ * Purpose of this class is to have single place for configuration of docker containers which are used and started in tests.
+ */
+public class DockerContainers {
+
+    private DockerContainers() {
+    } // avoid instantiation
+
+    public static Docker jaeger() {
+        return new Docker.Builder("jaeger", "jaegertracing/all-in-one:latest")
+                .setContainerReadyCondition(() -> {
+                    String address = "127.0.0.1";
+                    int port = 16686;
+                    try {
+                        new Socket(address, port).close();
+                        return true;
+                    } catch (IOException e) {
+                        // exception means port is not up
+                        return false;
+                    }
+                })
+                .setContainerReadyTimeout(180000) // 3 min
+                .wihtPortMapping("5775:5775/udp")
+                .wihtPortMapping("6831:6831/udp")
+                .wihtPortMapping("6832:6832/udp")
+                .wihtPortMapping("5778:5778")
+                .wihtPortMapping("16686:16686")
+                .wihtPortMapping("14250:14250")
+                .wihtPortMapping("14267:14267")
+                .wihtPortMapping("14268:14268")
+                .wihtPortMapping("9411:9411")
+                .withEnvVar("COLLECTOR_ZIPKIN_HTTP_PORT", "9411")
+                .withCmdArg("--reporter.grpc.host-port=localhost:14250")
+                .build();
+    }
+}

--- a/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/DockerTest.java
+++ b/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/DockerTest.java
@@ -1,0 +1,134 @@
+package org.jboss.eap.qe.ts.common.docker;
+
+import io.restassured.RestAssured;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.net.HttpURLConnection;
+import java.net.Socket;
+import java.net.URL;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class DockerTest {
+
+    private static final String DEFAULT_SERVER_BIND_ADDRESS = "127.0.0.1";
+    private static final String CONTAINER_NAME_WILDFLY_1 = "wildfly1";
+    private static final String CONTAINER_NAME_WILDFLY_2 = "wildfly2";
+    private static final int EXPOSED_HTTP_PORT_WILDFLY_1 = 11111;
+    private static final int EXPOSED_HTTP_PORT_WILDFLY_2 = 22222;
+    private static final int EXPOSED_MANAGEMENT_PORT_WILDFLY_1 = 11990;
+    private static final int EXPOSED_MANAGEMENT_PORT_WILDFLY_2 = 22990;
+
+    @ClassRule
+    public static Docker wildflyContainer = new Docker.Builder(CONTAINER_NAME_WILDFLY_1, "jboss/wildfly:18.0.0.Final")
+            .setContainerReadyTimeout(60000)
+            .setContainerReadyCondition(() -> {
+                try {
+                    URL url = new URL("http://" + DEFAULT_SERVER_BIND_ADDRESS + ":" + EXPOSED_MANAGEMENT_PORT_WILDFLY_1 + "/health");
+                    HttpURLConnection con = (HttpURLConnection) url.openConnection();
+                    con.setRequestMethod("GET");
+                    if (con.getResponseMessage().contains("OK")) {
+                        return true;
+                    }
+                } catch (Exception ex) {
+                    // exceptions means not ready
+                    return false;
+                }
+                return false;
+            })
+            .wihtPortMapping(EXPOSED_HTTP_PORT_WILDFLY_1 + ":8080")
+            .wihtPortMapping(EXPOSED_MANAGEMENT_PORT_WILDFLY_1 + ":9990")
+            .withCmdArg("/opt/jboss/wildfly/bin/standalone.sh")
+            .withCmdArg("-b=0.0.0.0")
+            .withCmdArg("-bmanagement=0.0.0.0")
+            .build();
+
+    @ClassRule
+    public static Docker wildflyContainer2 = new Docker.Builder(CONTAINER_NAME_WILDFLY_2, "jboss/wildfly:18.0.0.Final")
+            .setContainerReadyTimeout(60000)
+            .setContainerReadyCondition(() -> {
+                try {
+                    URL url = new URL("http://" + DEFAULT_SERVER_BIND_ADDRESS + ":" + EXPOSED_MANAGEMENT_PORT_WILDFLY_2 + "/health");
+                    HttpURLConnection con = (HttpURLConnection) url.openConnection();
+                    con.setRequestMethod("GET");
+                    if (con.getResponseMessage().contains("OK")) {
+                        return true;
+                    }
+                } catch (Exception ex) {
+                    // exceptions means not ready
+                    return false;
+                }
+                return false;
+            })
+            .wihtPortMapping(EXPOSED_HTTP_PORT_WILDFLY_2 + ":8080")
+            .wihtPortMapping(EXPOSED_MANAGEMENT_PORT_WILDFLY_2 + ":9990")
+            .withCmdArg("/opt/jboss/wildfly/bin/standalone.sh")
+            .withCmdArg("-b=0.0.0.0")
+            .withCmdArg("-bmanagement=0.0.0.0")
+            .build();
+
+    @Test
+    public void testHttpPortMappingWildfly1() {
+            Assert.assertTrue(CONTAINER_NAME_WILDFLY_1 + " container does not listion on port " + EXPOSED_HTTP_PORT_WILDFLY_1,
+                    isPortOpened(DEFAULT_SERVER_BIND_ADDRESS, EXPOSED_HTTP_PORT_WILDFLY_1));
+    }
+
+    @Test
+    public void testManagementPortMappingWildfly1() {
+        Assert.assertTrue(CONTAINER_NAME_WILDFLY_1 + " container does not listion on port " + EXPOSED_MANAGEMENT_PORT_WILDFLY_1,
+                isPortOpened(DEFAULT_SERVER_BIND_ADDRESS, EXPOSED_MANAGEMENT_PORT_WILDFLY_1));
+    }
+
+    @Test
+    public void testHttpPortMappingWildfly2() {
+        Assert.assertTrue(CONTAINER_NAME_WILDFLY_2 + " container does not listion on port " + EXPOSED_HTTP_PORT_WILDFLY_2,
+                isPortOpened(DEFAULT_SERVER_BIND_ADDRESS, EXPOSED_HTTP_PORT_WILDFLY_2));
+    }
+
+    @Test
+    public void testManagementPortMappingWildfly2() {
+        Assert.assertTrue(CONTAINER_NAME_WILDFLY_2 + " container does not listion on port " + EXPOSED_MANAGEMENT_PORT_WILDFLY_2,
+                isPortOpened(DEFAULT_SERVER_BIND_ADDRESS, EXPOSED_MANAGEMENT_PORT_WILDFLY_2));
+    }
+
+    /**
+     * Returns true if port on given addrress is open, otherwise false
+     *
+     * @param address IP address
+     * @param port port to check
+     */
+    private boolean isPortOpened(String address, int port) {
+        try {
+            new Socket(address, port).close();
+            return true;
+        } catch (Exception ex)  {
+            return false;
+        }
+    }
+
+    @Test
+    public void testWildlfy1WelcomePage() {
+        RestAssured.when().get("http://" + DEFAULT_SERVER_BIND_ADDRESS + ":" + EXPOSED_HTTP_PORT_WILDFLY_1).then().assertThat()
+                .body(containsString("Welcome to WildFly"));
+    }
+
+    @Test
+    public void testWildlfy2WelcomePage() {
+        RestAssured.when().get("http://" + DEFAULT_SERVER_BIND_ADDRESS + ":" + EXPOSED_HTTP_PORT_WILDFLY_2).then().assertThat()
+                .body(containsString("Welcome to WildFly"));
+    }
+
+    @Test
+    public void testWildlfy1HealthCheck() {
+        RestAssured.when().get("http://" + DEFAULT_SERVER_BIND_ADDRESS + ":" + EXPOSED_MANAGEMENT_PORT_WILDFLY_1 + "/health").then().assertThat()
+                .body(containsString("UP"));
+    }
+
+    @Test
+    public void testWildlfy2HealthCheck() {
+        RestAssured.when().get("http://" + DEFAULT_SERVER_BIND_ADDRESS + ":" + EXPOSED_MANAGEMENT_PORT_WILDFLY_2 + "/health").then().assertThat()
+                .body(containsString("UP"));
+    }
+}


### PR DESCRIPTION
Notes:

- testcontainers framework was not used as it requires docker daemon which is not on RHEL8 (where is podman)
- System.out will be used for printing docker output logs