### PR TITLE
Adding tooling for server configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
     <modules>
         <module>tooling-docker</module>
+        <module>tooling-server-config</module>
         <module>microprofile-health</module>
         <module>microprofile-metrics</module>
     </modules>
@@ -32,6 +33,8 @@
         <version.org.jboss.wildfly.dist>18.0.0.Final</version.org.jboss.wildfly.dist>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
+        <version.org.wildfly.core>10.0.3.Final</version.org.wildfly.core>
+        <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
     </properties>
 
     <dependencyManagement>
@@ -75,6 +78,28 @@
                 <groupId>org.fusesource.jansi</groupId>
                 <artifactId>jansi</artifactId>
                 <version>${version.org.fusesource.jansi}</version>
+            </dependency>
+            <!-- Wildfly CLI references used by tooling-server-config -->
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-controller-client</artifactId>
+                <version>${version.org.wildfly.core}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-cli</artifactId>
+                <version>${version.org.wildfly.core}</version>
+            </dependency>
+            <!-- Creaper by tooling-server-config -->
+            <dependency>
+                <groupId>org.wildfly.extras.creaper</groupId>
+                <artifactId>creaper-core</artifactId>
+                <version>${version.org.wildfly.extras.creaper}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.extras.creaper</groupId>
+                <artifactId>creaper-commands</artifactId>
+                <version>${version.org.wildfly.extras.creaper}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/tooling-server-config/README.md
+++ b/tooling-server-config/README.md
@@ -1,0 +1,37 @@
+# tooling-server-config
+ Leverages [Creaper] library to perform basic server configuration tasks.
+
+### Description 
+Based on a factory pattern in order to build instances of `OnlineManagementClient` or
+`OfflineManagementClient` instances provided by Creaper.
+
+The factory behavior is defined by `ManagmentClientFactory` interface which is implemented
+both by `StandaloneManagmentClientFactory` and `DomainManagmentClientFactory`, respectively able to provide
+management clients for instances of Wildfly running in _standalone_ or _domain_ mode.
+
+Common implementation for both the above mentioned classes is provided By `BaseManagementClientFactory`.
+
+### Tests
+Tests for this module aim at assessing that:
+ - Wildfly is running 
+ - Management client object instances:
+    - are returned by Creaper
+    - can execute common CLI commands like `whoami`
+    - can execute administrative operations (e.g.: `reload`)
+    - can add and remove extension/subsystem from server configuration
+    
+Common test behavior is provided by abstract base class `BaseManagmentClientTestCase`.
+
+See test cases, e.g. ManagementClientAgainstStandaloneModeTest.  
+
+Run tests with the following command, against a *running* Wildfly instance:
+```
+mvn clean verify -pl tooling-server-config -Dtest=ManagementClientAgainstStandaloneModeTest
+```
+
+or 
+
+```
+mvn clean verify -pl tooling-server-config -Dtest=ManagementClientAgainstDomainModeTest
+```
+

--- a/tooling-server-config/pom.xml
+++ b/tooling-server-config/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.eap.qe</groupId>
+        <artifactId>microprofile-test-suite</artifactId>
+        <version>1.0.0.Final-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>tooling-server-config</artifactId>
+
+    <dependencies>
+        <!-- Wildfly CLI references used by tooling-server-config -->
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-cli</artifactId>
+        </dependency>
+        <!-- Creaper by tooling-server-config -->
+        <dependency>
+            <groupId>org.wildfly.extras.creaper</groupId>
+            <artifactId>creaper-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.extras.creaper</groupId>
+            <artifactId>creaper-commands</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tooling-server-config/src/main/java/org/jboss/eap/qe/ts/common/server/config/BaseManagementClientFactory.java
+++ b/tooling-server-config/src/main/java/org/jboss/eap/qe/ts/common/server/config/BaseManagementClientFactory.java
@@ -1,0 +1,47 @@
+package org.jboss.eap.qe.ts.common.server.config;
+
+import org.wildfly.extras.creaper.core.ManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+
+import java.io.IOException;
+
+/**
+ * Provides common basic implementation of a factory for {@link ManagementClient} objects.
+ */
+public abstract class BaseManagementClientFactory implements ManagementClientFactory {
+
+    /**
+     * Default value for connection to managment client timeout, used when calling
+     * {@link ManagementClientFactory#createOnline(int)} method.
+     *
+     */
+    public static final int MANAGEMENT_CLIENT_CONNECTION_TIMEOUT_IN_SEC = 10;
+
+    protected final String name;
+    protected final String host;
+    protected final int port;
+
+    BaseManagementClientFactory(String name, String host, int port) {
+        this.name = name;
+        this.host = host;
+        this.port = port;
+    }
+
+    /**
+     * Gets the value - in seconds - for managment client connection timout.
+     * @return returns {@link BaseManagementClientFactory#MANAGEMENT_CLIENT_CONNECTION_TIMEOUT_IN_SEC} value
+     */
+    public int getManagementClientConnectionTimeoutInSec() {
+        return (int)MANAGEMENT_CLIENT_CONNECTION_TIMEOUT_IN_SEC;
+    }
+
+    /**
+     * Creates Creaper {@link OnlineManagementClient}, which can be used for server configuration.
+     * Note that <b>it's the caller's responsibility</b> to {@code close} the {@code OnlineManagementClient}!
+     * @return {@link }{@link OnlineManagementClient} instance
+     * @throws IOException
+     */
+    public OnlineManagementClient createOnline() throws IOException {
+        return createOnline(1000 * getManagementClientConnectionTimeoutInSec());
+    }
+}

--- a/tooling-server-config/src/main/java/org/jboss/eap/qe/ts/common/server/config/DomainManagementClientFactory.java
+++ b/tooling-server-config/src/main/java/org/jboss/eap/qe/ts/common/server/config/DomainManagementClientFactory.java
@@ -1,0 +1,99 @@
+package org.jboss.eap.qe.ts.common.server.config;
+
+import org.wildfly.extras.creaper.core.ManagementClient;
+import org.wildfly.extras.creaper.core.offline.OfflineManagementClient;
+import org.wildfly.extras.creaper.core.offline.OfflineOptions;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineOptions;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Factory for {@link ManagementClient} objects to work against a Wildfly instance running in <b>domain</b> mode.
+ */
+public class DomainManagementClientFactory extends BaseManagementClientFactory {
+
+    private final String defaultProfile;
+    private final String defaultHost;
+
+    private DomainManagementClientFactory(String name, String host, int port, String defaultProfile,
+                                          String defaultHost) {
+        super(name, host, port);
+        this.defaultProfile = defaultProfile;
+        this.defaultHost = defaultHost;
+    }
+
+    /**
+     * As {@link ManagementClientFactory#createOnline()}, but you can define a positive connection
+     * timeout in milliseconds.
+     * @param timeoutInMillis int for milliseconds that represent the timeout for connection to management client to
+     *                        be created.
+     * @return {@link }{@link OfflineManagementClient} instance
+     * @throws IOException Thrown when no connection can be enabled between client and server
+     */
+    @Override
+    public OnlineManagementClient createOnline(int timeoutInMillis) throws IOException {
+        OnlineOptions.ConnectionOnlineOptions options =
+                OnlineOptions.domain().forProfile(defaultProfile).forHost(defaultHost).build();
+
+        OnlineOptions.OptionalOnlineOptions clientOptions = options
+                .hostAndPort(host, port)
+                .connectionTimeout(timeoutInMillis);
+
+        return ManagementClient.online(clientOptions.build());
+    }
+
+    /**
+     * Creates Creaper {@link OfflineManagementClient}, which can be used for server configuration.
+     * Note that <b>it's the caller's responsibility</b> to {@code close} the {@code OnlineManagementClient}!
+     *
+     * @param rootDirectory Wildfly root directory
+     * @param configurationFile Wildfly configuration file (e.g.: standalone.xml, standalone-full.xml etc.)
+     * @return {@link }{@link OfflineManagementClient} instance
+     * @throws IOException Thrown when no connection can be enabled between client and server
+     */
+    @Override
+    public OfflineManagementClient createOffline(String rootDirectory, String configurationFile) throws IOException {
+        return ManagementClient.offline(OfflineOptions
+                .domain()
+                .forProfile("default")
+                .build()
+                .rootDirectory(new File(rootDirectory))
+                .configurationFile(configurationFile)
+                .build()
+        );
+    }
+
+    public static final class Builder {
+
+        private String host;
+        private int port;
+        private String defaultProfile;
+        private String defaultHost;
+
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder defaultProfile(String defaultProfile) {
+            this.defaultProfile = defaultProfile;
+            return this;
+        }
+
+        public Builder defaultHost(String defaultHost) {
+            this.defaultHost = defaultHost;
+            return this;
+        }
+
+        public DomainManagementClientFactory build(String withName) {
+            return new DomainManagementClientFactory(withName, host, port, defaultProfile, defaultHost);
+        }
+    }
+}

--- a/tooling-server-config/src/main/java/org/jboss/eap/qe/ts/common/server/config/ManagementClientFactory.java
+++ b/tooling-server-config/src/main/java/org/jboss/eap/qe/ts/common/server/config/ManagementClientFactory.java
@@ -1,0 +1,40 @@
+package org.jboss.eap.qe.ts.common.server.config;
+
+import org.wildfly.extras.creaper.core.offline.OfflineManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+
+import java.io.IOException;
+
+/**
+ * Interface to define the contract for implementing management client factory instances using Creaper
+ */
+public interface ManagementClientFactory {
+    /**
+     * Creates Creaper {@link OnlineManagementClient}, which can be used for server configuration.
+     * Note that <b>it's the caller's responsibility</b> to {@code close} the {@code OnlineManagementClient}!
+     * @return {@link }{@link OnlineManagementClient} instance
+     * @throws IOException
+     */
+    OnlineManagementClient createOnline() throws IOException;
+
+    /**
+     * As {@link ManagementClientFactory#createOnline()}, but you can define a positive connection
+     * timeout in milliseconds.
+     * @param timeoutInMillis int for milliseconds that represent the timeout for connection to management client to
+     *                        be created.
+     * @return {@link }{@link OfflineManagementClient} instance
+     * @throws IOException Thrown when no connection can be enabled between client and server
+     */
+    OnlineManagementClient createOnline(int timeoutInMillis) throws IOException;
+
+    /**
+     * Creates Creaper {@link OfflineManagementClient}, which can be used for server configuration.
+     * Note that <b>it's the caller's responsibility</b> to {@code close} the {@code OnlineManagementClient}!
+     *
+     * @param rootDirectory Wildfly root directory
+     * @param configurationFile Wildfly configuration file (e.g.: standalone.xml, standalone-full.xml etc.)
+     * @return {@link }{@link OfflineManagementClient} instance
+     * @throws IOException Thrown when no connection can be enabled between client and server
+     */
+    OfflineManagementClient createOffline(String rootDirectory, String configurationFile) throws IOException;
+}

--- a/tooling-server-config/src/main/java/org/jboss/eap/qe/ts/common/server/config/RemoveDatasource.java
+++ b/tooling-server-config/src/main/java/org/jboss/eap/qe/ts/common/server/config/RemoveDatasource.java
@@ -1,0 +1,21 @@
+package org.jboss.eap.qe.ts.common.server.config;
+
+import org.wildfly.extras.creaper.commands.foundation.online.CliFile;
+import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.online.OnlineCommand;
+import org.wildfly.extras.creaper.core.online.OnlineCommandContext;
+
+/**
+ * Class that implements a command for Creaper to execute and CLI to remove a datasource configuration.
+ */
+public class RemoveDatasource implements OnlineCommand {
+    @Override
+    public void apply(OnlineCommandContext ctx) throws CommandFailedException {
+        ctx.client.apply(new CliFile(RemoveDatasource.class));
+    }
+
+    @Override
+    public String toString() {
+        return "RemoveDatasource";
+    }
+}

--- a/tooling-server-config/src/main/java/org/jboss/eap/qe/ts/common/server/config/SetupDatasource.java
+++ b/tooling-server-config/src/main/java/org/jboss/eap/qe/ts/common/server/config/SetupDatasource.java
@@ -1,0 +1,21 @@
+package org.jboss.eap.qe.ts.common.server.config;
+
+import org.wildfly.extras.creaper.commands.foundation.online.CliFile;
+import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.online.OnlineCommand;
+import org.wildfly.extras.creaper.core.online.OnlineCommandContext;
+
+/**
+ * Class that implements a command for Creaper to execute and CLI to add a datasource configuration.
+ */
+public class SetupDatasource implements OnlineCommand {
+    @Override
+    public void apply(OnlineCommandContext ctx) throws CommandFailedException {
+        ctx.client.apply(new CliFile(SetupDatasource.class));
+    }
+
+    @Override
+    public String toString() {
+        return "SetupDatasource";
+    }
+}

--- a/tooling-server-config/src/main/java/org/jboss/eap/qe/ts/common/server/config/StandaloneManagementClientFactory.java
+++ b/tooling-server-config/src/main/java/org/jboss/eap/qe/ts/common/server/config/StandaloneManagementClientFactory.java
@@ -1,0 +1,78 @@
+package org.jboss.eap.qe.ts.common.server.config;
+
+import org.wildfly.extras.creaper.core.ManagementClient;
+import org.wildfly.extras.creaper.core.offline.OfflineManagementClient;
+import org.wildfly.extras.creaper.core.offline.OfflineOptions;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineOptions;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Factory for {@link ManagementClient} objects to work against a Wildfly instance running in <b>standalone</b> mode.
+ */
+public class StandaloneManagementClientFactory extends BaseManagementClientFactory implements ManagementClientFactory {
+
+    private StandaloneManagementClientFactory(String name, String host, int port) {
+        super(name, host, port);
+    }
+
+    /**
+     * As {@link ManagementClientFactory#createOnline()}, but you can define a positive connection
+     * timeout in milliseconds.
+     * @param timeoutInMillis int for milliseconds that represent the timeout for connection to management client to
+     *                        be created.
+     * @return {@link }{@link OfflineManagementClient} instance
+     * @throws IOException Thrown when no connection can be enabled between client and server
+     */
+    @Override
+    public OnlineManagementClient createOnline(int timeoutInMillis) throws IOException {
+        OnlineOptions.ConnectionOnlineOptions options = OnlineOptions.standalone();
+
+        OnlineOptions.OptionalOnlineOptions clientOptions = options
+                .hostAndPort(host, port)
+                .connectionTimeout(timeoutInMillis);
+
+        return ManagementClient.online(clientOptions.build());
+    }
+
+    /**
+     * Creates Creaper {@link OfflineManagementClient}, which can be used for server configuration.
+     * Note that <b>it's the caller's responsibility</b> to {@code close} the {@code OnlineManagementClient}!
+     *
+     * @param rootDirectory Wildfly root directory
+     * @param configurationFile Wildfly configuration file (e.g.: standalone.xml, standalone-full.xml etc.)
+     * @return {@link }{@link OfflineManagementClient} instance
+     * @throws IOException Thrown when no connection can be enabled between client and server
+     */
+    @Override
+    public OfflineManagementClient createOffline(String rootDirectory, String configurationFile) throws IOException {
+        return ManagementClient.offline(OfflineOptions
+                .standalone()
+                .rootDirectory(new File(rootDirectory))
+                .configurationFile(configurationFile)
+                .build()
+        );
+    }
+
+    public static final class Builder {
+
+        private String host;
+        private int port;
+
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        public StandaloneManagementClientFactory build(String withName) {
+            return new StandaloneManagementClientFactory(withName, host, port);
+        }
+    }
+}

--- a/tooling-server-config/src/main/resources/org/jboss/eap/qe/ts/common/server/config/RemoveDatasource.cli
+++ b/tooling-server-config/src/main/resources/org/jboss/eap/qe/ts/common/server/config/RemoveDatasource.cli
@@ -1,0 +1,1 @@
+/subsystem=datasources/data-source=testDS:remove()

--- a/tooling-server-config/src/main/resources/org/jboss/eap/qe/ts/common/server/config/SetupDatasource.cli
+++ b/tooling-server-config/src/main/resources/org/jboss/eap/qe/ts/common/server/config/SetupDatasource.cli
@@ -1,0 +1,1 @@
+/subsystem=datasources/data-source=testDS:add(driver-name=h2,jndi-name="java:/info/datasources/testDS",connection-url="jdbc:h2:test:mane")

--- a/tooling-server-config/src/test/java/org/jboss/eap/qe/ts/common/server/config/BaseManagementClientTestCase.java
+++ b/tooling-server-config/src/test/java/org/jboss/eap/qe/ts/common/server/config/BaseManagementClientTestCase.java
@@ -1,0 +1,90 @@
+package org.jboss.eap.qe.ts.common.server.config;
+
+import org.hamcrest.Matchers;
+import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.online.CliException;
+import org.wildfly.extras.creaper.core.online.ModelNodeResult;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.util.concurrent.TimeoutException;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Base implementation for management client test cases
+ */
+public abstract class BaseManagementClientTestCase {
+
+    public static final String WILDFLY_DEFAULT_BIND_ADDRESS = "127.0.0.1";
+    public static final int WILDFLY_DEFAULT_EXPOSED_HTTP_PORT = 8080;
+    public static final int WILDFLY_DEFAULT_EXPOSED_MANAGEMENT_PORT = 9990;
+
+    protected static boolean portOpened(int port) {
+        try {
+            new Socket(WILDFLY_DEFAULT_BIND_ADDRESS, port).close();
+        } catch (Exception ex) {
+            return false;
+        }
+        return true;
+    }
+
+    protected abstract String getWildflyName();
+
+    protected abstract ManagementClientFactory getManagementClientFactory();
+
+    protected String getWildflyRootDirectory() {
+        return System.getProperty("jboss.home");
+    }
+
+    protected abstract String getWildflyConfigurationFile();
+
+    protected void doTestManagementPortMapping() {
+        assertThat(getWildflyName() + " container is not listening on port " + WILDFLY_DEFAULT_EXPOSED_MANAGEMENT_PORT,
+                portOpened(WILDFLY_DEFAULT_EXPOSED_MANAGEMENT_PORT), is(true));
+    }
+
+    protected void doTestWelcomePageAvailable() {
+        get("http://" + WILDFLY_DEFAULT_BIND_ADDRESS + ":" + WILDFLY_DEFAULT_EXPOSED_HTTP_PORT).then()
+                .body(containsString("Welcome to WildFly"));
+    }
+
+    protected void doTestOnlineManagementClientAvailable() throws IOException {
+        assertThat(getWildflyName() + " management client is not available ",
+                getManagementClientFactory().createOnline(), Matchers.notNullValue());
+    }
+
+    protected void doTestOnlineManagementClientReturnsWhoami() throws IOException, CliException {
+        OnlineManagementClient client = getManagementClientFactory().createOnline();
+        ModelNodeResult result = client.execute(":whoami");
+        result.assertSuccess();
+        System.out.println(result.get("result", "identity", "username"));
+    }
+
+    protected void doTestOnlineAdministrationManagementClientReload() throws IOException, InterruptedException, TimeoutException {
+        OnlineManagementClient client = getManagementClientFactory().createOnline();
+        Administration admin = new Administration(client);
+        admin.reload();
+    }
+
+    public void doTestOnlineManagementClientAddingAndRemovingDatasource() throws IOException, CommandFailedException, CliException {
+        OnlineManagementClient client = getManagementClientFactory().createOnline();
+        client.apply(new SetupDatasource());
+        //
+        ModelNodeResult result = client.execute("/subsystem=datasources:read-resource");
+        result.assertSuccess();
+        System.out.println(result.get("result"));
+        //
+        client.apply(new RemoveDatasource());
+    }
+
+    protected void doTestOfflineManagementClientAvailable(String rootDirectory, String configurationFile) throws IOException {
+        assertThat(getWildflyName() + " offline management client is not available ",
+                getManagementClientFactory().createOffline(rootDirectory, configurationFile), Matchers.notNullValue());
+    }
+}

--- a/tooling-server-config/src/test/java/org/jboss/eap/qe/ts/common/server/config/ExternalizedManagemntClientResource.java
+++ b/tooling-server-config/src/test/java/org/jboss/eap/qe/ts/common/server/config/ExternalizedManagemntClientResource.java
@@ -1,0 +1,63 @@
+package org.jboss.eap.qe.ts.common.server.config;
+
+import org.junit.rules.ExternalResource;
+import org.wildfly.extras.creaper.core.offline.OfflineManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+
+import java.io.IOException;
+
+/**
+ * Provides a convenient wrapper for @{@link BaseManagementClientFactory} instances to be used as {@link ExternalResource}
+ * @param <F> type of {@link BaseManagementClientFactory}
+ */
+public class ExternalizedManagemntClientResource<F extends BaseManagementClientFactory>
+        extends ExternalResource implements ManagementClientFactory {
+
+    private final F factory;
+
+    public ExternalizedManagemntClientResource(F factory) {
+        this.factory = factory;
+    }
+
+    /**
+     * Creates Creaper {@link OnlineManagementClient}, which can be used for server configuration.
+     * Note that <b>it's the caller's responsibility</b> to {@code close} the {@code OnlineManagementClient}!
+     * @return {@link }{@link OnlineManagementClient} instance
+     * @throws IOException
+     */
+    @Override
+    public OnlineManagementClient createOnline() throws IOException {
+        return factory.createOnline();
+    }
+
+    /**
+     * As {@link ManagementClientFactory#createOnline()}, but you can define a positive connection
+     * timeout in milliseconds.
+     * @param timeoutInMillis int for milliseconds that represent the timeout for connection to management client to
+     *                        be created.
+     * @return {@link }{@link OfflineManagementClient} instance
+     * @throws IOException Thrown when no connection can be enabled between client and server
+     */
+    @Override
+    public OnlineManagementClient createOnline(int timeoutInMillis) throws IOException {
+        return factory.createOnline(timeoutInMillis);
+    }
+
+    /**
+     * Creates Creaper {@link OfflineManagementClient}, which can be used for server configuration.
+     * Note that <b>it's the caller's responsibility</b> to {@code close} the {@code OnlineManagementClient}!
+     *
+     * @param rootDirectory Wildfly root directory
+     * @param configurationFile Wildfly configuration file (e.g.: standalone.xml, standalone-full.xml etc.)
+     * @return {@link }{@link OfflineManagementClient} instance
+     * @throws IOException Thrown when no connection can be enabled between client and server
+     */
+    @Override
+    public OfflineManagementClient createOffline(String rootDirectory, String configurationFile) {
+        return createOffline(rootDirectory, configurationFile);
+    }
+
+    public F unwrap() {
+        return factory;
+    }
+}

--- a/tooling-server-config/src/test/java/org/jboss/eap/qe/ts/common/server/config/ManagementClientAgainstDomainModeTest.java
+++ b/tooling-server-config/src/test/java/org/jboss/eap/qe/ts/common/server/config/ManagementClientAgainstDomainModeTest.java
@@ -1,0 +1,94 @@
+package org.jboss.eap.qe.ts.common.server.config;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.online.CliException;
+import org.wildfly.extras.creaper.core.online.ModelNodeResult;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Test case to verify {@link BaseManagementClientFactory} features - together with Creaper implementations for both
+ * on-line and off-line management clients - against Wildfly running in standalone mode.
+ */
+public class ManagementClientAgainstDomainModeTest extends BaseManagementClientTestCase {
+
+    private static final String WILDFLY_NAME = "domain-wildfly";
+
+    @Override
+    protected String getWildflyName() {
+        return WILDFLY_NAME;
+    }
+
+    @Override
+    protected ManagementClientFactory getManagementClientFactory() {
+        return managementClientFactoryResource.unwrap();
+    }
+
+    @Override
+    protected String getWildflyConfigurationFile()  {
+        return "domain.xml";
+    }
+
+    @ClassRule
+    public static ExternalizedManagemntClientResource<DomainManagementClientFactory> managementClientFactoryResource =
+        new ExternalizedManagemntClientResource<>(
+                new DomainManagementClientFactory.Builder()
+                        .host(WILDFLY_DEFAULT_BIND_ADDRESS)
+                        .port(9990)
+                        .defaultProfile("default")
+                        .defaultHost("master")
+                        .build(WILDFLY_NAME)
+        );
+
+    @Test
+    public void testManagementPortMapping() {
+        doTestManagementPortMapping();
+    }
+
+    @Test
+    public void testWelcomePageAvailable() {
+        doTestWelcomePageAvailable();
+    }
+
+    @Test
+    public void testOnlineManagementClientAvailable() throws IOException {
+        doTestOnlineManagementClientAvailable();
+    }
+
+    @Test
+    public void testOnlineManagementClientReturnsWhoami() throws IOException, CliException {
+        doTestOnlineManagementClientReturnsWhoami();
+    }
+
+    @Test
+    public void testOnlineAdministrationManagementClientReload() throws IOException, InterruptedException, TimeoutException {
+        doTestOnlineAdministrationManagementClientReload();
+    }
+
+    @Test
+    public void testOnlineManagementClientAddAndRemoveOpenApiExtensionAndSubsystem() throws IOException {
+        OnlineManagementClient client = getManagementClientFactory().createOnline();
+        Operations ops = new Operations(client);
+        ModelNodeResult result = ops.add(Address.root()
+                .and("extension", "org.wildfly.extension.microprofile.openapi-smallrye"));
+        result.assertSuccess();
+        result = ops.remove(Address.root().and("extension", "org.wildfly.extension.microprofile.openapi-smallrye"));
+        result.assertSuccess();
+    }
+
+    @Test
+    public void testOnlineManagementClientAddingAndRemovingDatasource() throws IOException, CommandFailedException, CliException {
+        doTestOnlineManagementClientAddingAndRemovingDatasource();
+    }
+
+    @Test
+    public void testOfflineManagementClientAvailable() throws IOException {
+        doTestOfflineManagementClientAvailable(getWildflyRootDirectory(), getWildflyConfigurationFile());
+    }
+}

--- a/tooling-server-config/src/test/java/org/jboss/eap/qe/ts/common/server/config/ManagementClientAgainstStandaloneModeTest.java
+++ b/tooling-server-config/src/test/java/org/jboss/eap/qe/ts/common/server/config/ManagementClientAgainstStandaloneModeTest.java
@@ -1,0 +1,104 @@
+package org.jboss.eap.qe.ts.common.server.config;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.online.CliException;
+import org.wildfly.extras.creaper.core.online.ModelNodeResult;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+
+/**
+ * Test case to verify {@link BaseManagementClientFactory} features - together with Creaper implementations for both
+ * on-line and off-line management clients - against Wildfly running in standalone mode.
+ */
+public class ManagementClientAgainstStandaloneModeTest extends BaseManagementClientTestCase {
+    private static final String WILDFLY_NAME = "standalone-wildfly";
+
+    @Override
+    protected String getWildflyName() {
+        return WILDFLY_NAME;
+    }
+
+    @Override
+    protected ManagementClientFactory getManagementClientFactory() {
+        return managementClientFactoryResource.unwrap();
+    }
+
+    @Override
+    protected String getWildflyConfigurationFile()  {
+        return "standalone.xml";
+    }
+
+    @ClassRule
+    public static ExternalizedManagemntClientResource<StandaloneManagementClientFactory> managementClientFactoryResource =
+            new ExternalizedManagemntClientResource<>(
+                    new StandaloneManagementClientFactory.Builder()
+                        .host(WILDFLY_DEFAULT_BIND_ADDRESS)
+                        .port(9990)
+                        .build(WILDFLY_NAME)
+            );
+
+    @Test
+    public void testManagementPortMapping() {
+        doTestManagementPortMapping();
+    }
+
+    @Test
+    public void testWelcomePageAvailable() {
+        doTestWelcomePageAvailable();
+    }
+
+    @Test
+    public void testOnlineManagementClientAvailable() throws IOException {
+        doTestOnlineManagementClientAvailable();
+    }
+
+    @Test
+    public void testOnlineManagementClientReturnsWhoami() throws IOException, CliException {
+        doTestOnlineManagementClientReturnsWhoami();
+    }
+
+    @Test
+    public void testOnlineAdministrationManagementClientReload() throws IOException, InterruptedException, TimeoutException {
+        doTestOnlineAdministrationManagementClientReload();
+    }
+
+    @Test
+    public void testOnlineManagementClientAddAndRemoveOpenApiExtensionAndSubsystem() throws IOException, CliException {
+        OnlineManagementClient client = getManagementClientFactory().createOnline();
+        ModelNodeResult result = client.execute(
+                "/extension=org.wildfly.extension.microprofile.openapi-smallrye:add");
+        result.assertSuccess();
+        result = client.execute(
+                "/:composite(steps=[{\"operation\" => \"add\",\"address\" => [(\"subsystem\" => \"microprofile-openapi-smallrye\")]}])");
+        result.assertSuccess();
+        result = client.execute(
+                "/:composite(steps=[{\"operation\" => \"remove\",\"address\" => [(\"subsystem\" => \"microprofile-openapi-smallrye\")]}])");
+        result.assertSuccess();
+        result = client.execute(
+                "/extension=org.wildfly.extension.microprofile.openapi-smallrye:remove");
+        result.assertSuccess();
+    }
+
+    @Test
+    public void testOnlineManagementClientAddingAndRemovingDatasource() throws IOException, CommandFailedException, CliException {
+        doTestOnlineManagementClientAddingAndRemovingDatasource();
+    }
+
+    @Test
+    public void testOnlineManagementClientListLogFiles() throws IOException, CliException {
+        OnlineManagementClient client = getManagementClientFactory().createOnline();
+        ModelNodeResult result = client.execute("/subsystem=logging:list-log-files");
+        result.assertSuccess();
+        System.out.println(result.get("result"));
+    }
+
+    @Test
+    public void testOfflineManagementClientAvailable() throws IOException {
+        doTestOfflineManagementClientAvailable(getWildflyRootDirectory(), getWildflyConfigurationFile());
+    }
+}


### PR DESCRIPTION
Adding tooling for server configuration.

Tooling is leveraging Creaper capabilities in order to obtain on-line and off-line management clients to perform server configuration tasks. See module README.md file for further details



Please make sure your PR meets the following requirements:
- [x] Pull Request contains description for the changes
- [x] Pull Request does not include fixes for multiple issues / topics
- [x] Code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
