### PR TITLE
Ensure UTF_8 is used

### DIFF
--- a/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/Docker.java
+++ b/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/Docker.java
@@ -6,6 +6,7 @@ import org.junit.rules.ExternalResource;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -72,7 +73,7 @@ public class Docker extends ExternalResource {
                 .start();
 
         outputPrinter.execute(() -> {
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(dockerRunProcess.getInputStream()))) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(dockerRunProcess.getInputStream(), StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
                     System.out.println(Ansi.ansi().fgCyan().a(name).reset().a("> ").a(line));
@@ -135,7 +136,7 @@ public class Docker extends ExternalResource {
 
         dockerRunProcess.waitFor();
 
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(dockerRunProcess.getInputStream()))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(dockerRunProcess.getInputStream(), StandardCharsets.UTF_8))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 if (line.contains(uuid))    {


### PR DESCRIPTION
Ensure UTF_8 is used and we don't depend on platform default encoding

Detected by Coverity scan

Please make sure your PR meets the following requirements:
- [x] Pull Request contains description for the changes
- [x] Pull Request does not include fixes for multiple issues / topics
- [x] Code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
