### PR TITLE
Adding foundation for Creaper integration to operate CLI and CLI integration tests

### DIFF
--- a/microprofile-open-api/pom.xml
+++ b/microprofile-open-api/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>microprofile-test-suite</artifactId>
+        <groupId>org.jboss.eap.qe</groupId>
+        <version>1.0.0.Final-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>microprofile-open-api</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Wildfly CLI references used by tooling-server-config -->
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-cli</artifactId>
+        </dependency>
+        <!-- Creaper by tooling-server-config -->
+        <dependency>
+            <groupId>org.wildfly.extras.creaper</groupId>
+            <artifactId>creaper-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-managed</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.eap.qe</groupId>
+            <artifactId>tooling-server-configuration</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/OpenApiManagementClientHelper.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/OpenApiManagementClientHelper.java
@@ -1,0 +1,127 @@
+package org.jboss.eap.qe.microprofile.openapi;
+
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientHelper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientRelatedException;
+import org.wildfly.extras.creaper.core.online.ModelNodeResult;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.OperationException;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Helper that provides operations to manage the OpenAPI extension configuration via
+ * {@link OnlineManagementClient} API.
+ */
+public class OpenApiManagementClientHelper {
+
+    /**
+     * Executes CLI command to remove MP OpenAPI extension
+     *
+     * @param client {@link OnlineManagementClient} instance used to execute the command
+     * @return {@link ModelNodeResult} instance to represent the command execution outcome
+     * @throws ManagementClientRelatedException Wraps exceptions thrown by the internal operation executed by
+     *                                          {@link OnlineManagementClient} API
+     */
+    public static ModelNodeResult removeOpenApiExtension(OnlineManagementClient client) throws ManagementClientRelatedException {
+        return ManagementClientHelper.executeCliCommand(client,
+                "/extension=org.wildfly.extension.microprofile.openapi-smallrye:remove");
+    }
+
+    /**
+     * Executes CLI command to remove MP OpenAPI subsystem
+     *
+     * @param client {@link OnlineManagementClient} instance used to execute the command
+     * @return {@link ModelNodeResult} instance to represent the command execution outcome
+     * @throws ManagementClientRelatedException Wraps exceptions thrown by the internal operation executed by
+     *                                          {@link OnlineManagementClient} API
+     */
+    public static ModelNodeResult removeOpenApiSubsystem(OnlineManagementClient client) throws ManagementClientRelatedException {
+        return ManagementClientHelper.executeCliCommand(client,
+                "/subsystem=microprofile-openapi-smallrye:remove");
+    }
+
+    /**
+     * Executes CLI command to add MP OpenAPI subsystem
+     *
+     * @param client {@link OnlineManagementClient} instance used to execute the command
+     * @return {@link ModelNodeResult} instance to represent the command execution outcome
+     * @throws ManagementClientRelatedException Wraps exceptions thrown by the internal operation executed by
+     *                                          {@link OnlineManagementClient} API
+     */
+    public static ModelNodeResult addOpenApiSubsystem(OnlineManagementClient client) throws ManagementClientRelatedException {
+        return ManagementClientHelper.executeCliCommand(client,
+                "/subsystem=microprofile-openapi-smallrye:add");
+    }
+
+    /**
+     * Executes CLI command to add MP OpenAPI extension
+     *
+     * @param client {@link OnlineManagementClient} instance used to execute the command
+     * @return {@link ModelNodeResult} instance to represent the command execution outcome
+     * @throws ManagementClientRelatedException Wraps exceptions thrown by the internal operation executed by
+     *                                          {@link OnlineManagementClient} API
+     */
+    public static ModelNodeResult addOpenApiExtension(OnlineManagementClient client) throws ManagementClientRelatedException {
+        return ManagementClientHelper.executeCliCommand(client,
+                "/extension=org.wildfly.extension.microprofile.openapi-smallrye:add");
+    }
+
+    /**
+     * Executes a batch of CLI commands to enable MP OpenAPI feature
+     *
+     * @param client {@link OnlineManagementClient} instance used to execute the command
+     * @throws ManagementClientRelatedException Wraps exceptions thrown by the internal operation executed by
+     *                                          {@link OnlineManagementClient} API
+     */
+    public static void enableOpenApi(OnlineManagementClient client) throws ManagementClientRelatedException {
+        try {
+            ModelNodeResult result = addOpenApiExtension(client);
+            result.assertSuccess();
+            result = addOpenApiSubsystem(client);
+            result.assertSuccess();
+            new Administration(client).reload();
+        } catch (TimeoutException | IOException | InterruptedException e) {
+            throw new ManagementClientRelatedException(e);
+        }
+    }
+
+    /**
+     * Executes a batch of CLI commands to disable MP OpenAPI feature
+     *
+     * @param client {@link OnlineManagementClient} instance used to execute the command
+     * @throws ManagementClientRelatedException Wraps exceptions thrown by the internal operation executed by
+     *                                          {@link OnlineManagementClient} API
+     */
+    public static void disableOpenApi(OnlineManagementClient client) throws ManagementClientRelatedException {
+        try {
+            ModelNodeResult result = removeOpenApiSubsystem(client);
+            result.assertSuccess();
+            result = removeOpenApiExtension(client);
+            result.assertSuccess();
+            new Administration(client).reload();
+        } catch (TimeoutException | IOException | InterruptedException e) {
+            throw new ManagementClientRelatedException(e);
+        }
+    }
+
+    /**
+     * Checks whether <b>"org.wildfly.extension.microprofile.openapi-smallrye"</b> subsytem is present
+     *
+     * @param client {@link OnlineManagementClient} instance used to execute the command
+     * @return True if subsystem is already present,false otherwise
+     * @throws ManagementClientRelatedException Wraps exceptions thrown by the internal operation executed by
+     *                                          {@link OnlineManagementClient} API
+     */
+    public static Boolean openapiSubsystemExists(OnlineManagementClient client) throws ManagementClientRelatedException {
+        Operations ops = new Operations(client);
+        try {
+            return ops.exists(Address.extension("org.wildfly.extension.microprofile.openapi-smallrye"));
+        } catch (IOException | OperationException e) {
+            throw new ManagementClientRelatedException(e);
+        }
+    }
+}

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/cli/ConfigureMicroProfileOpenApiExtensionTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/cli/ConfigureMicroProfileOpenApiExtensionTest.java
@@ -1,0 +1,46 @@
+package org.jboss.eap.qe.microprofile.openapi.integration.cli;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.eap.qe.microprofile.openapi.OpenApiManagementClientHelper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientHelper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientRelatedException;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
+import java.io.IOException;
+
+/**
+ * Test cases for MP OpenAPI feature subsystem configuration
+ */
+@RunWith(Arquillian.class)
+public class ConfigureMicroProfileOpenApiExtensionTest {
+
+    static ArquillianContainerProperties arquillianContainerProperties = new ArquillianContainerProperties(ArquillianDescriptorWrapper.getArquillianDescriptor());
+
+    /**
+     * @tpTestDetails Testing CLI operations to configure subsystem (add and removal)
+     * @tpPassCrit Uses {@link ManagementClientHelper} API to verify MP OpenAPI feature subsystem does not exist and
+     * then executes commands needed for its initialization and finalization.
+     * @tpSince EAP 7.4.0.CD19
+     *
+     * @throws ManagementClientRelatedException Wraps exceptions thrown by the internal operation executed by
+     *                                          {@link OnlineManagementClient} API
+     * @throws IOException
+     * @throws ConfigurationException           Wraps exceptions thrown by the internal operation executed by
+     *                                          {@link ArquillianContainerProperties} API
+     */
+    @Test
+    public void testAddAndRemoveExtensionAndSubsystem() throws ManagementClientRelatedException, IOException, ConfigurationException {
+        //  MP OpenAPI up & down
+        try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone(arquillianContainerProperties))   {
+            if (!OpenApiManagementClientHelper.openapiSubsystemExists(client)) {
+                OpenApiManagementClientHelper.enableOpenApi(client);
+                OpenApiManagementClientHelper.disableOpenApi(client);
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,10 @@
 
     <modules>
         <module>tooling-docker</module>
+        <module>tooling-server-configuration</module>
         <module>microprofile-health</module>
         <module>microprofile-metrics</module>
+        <module>microprofile-open-api</module>
     </modules>
 
     <properties>
@@ -32,6 +34,8 @@
         <version.org.jboss.wildfly.dist>18.0.0.Final</version.org.jboss.wildfly.dist>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
+        <version.org.wildfly.core>10.0.3.Final</version.org.wildfly.core>
+        <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
     </properties>
 
     <dependencyManagement>
@@ -75,6 +79,29 @@
                 <groupId>org.fusesource.jansi</groupId>
                 <artifactId>jansi</artifactId>
                 <version>${version.org.fusesource.jansi}</version>
+            </dependency>
+            <!-- Arquillian container test SPI for extension -->
+            <dependency>
+                <groupId>org.jboss.arquillian.container</groupId>
+                <artifactId>arquillian-container-test-spi</artifactId>
+                <version>${version.org.jboss.arquillian}</version>
+            </dependency>
+            <!-- Wildfly CLI references used by tooling-server-config -->
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-controller-client</artifactId>
+                <version>${version.org.wildfly.core}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-cli</artifactId>
+                <version>${version.org.wildfly.core}</version>
+            </dependency>
+            <!-- Creaper by tooling-server-config -->
+            <dependency>
+                <groupId>org.wildfly.extras.creaper</groupId>
+                <artifactId>creaper-core</artifactId>
+                <version>${version.org.wildfly.extras.creaper}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/tooling-server-configuration/pom.xml
+++ b/tooling-server-configuration/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>microprofile-test-suite</artifactId>
+        <groupId>org.jboss.eap.qe</groupId>
+        <version>1.0.0.Final-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>tooling-server-configuration</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Arquillian container test SPI for extension -->
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <!-- Wildfly CLI references used by tooling-server-config -->
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-cli</artifactId>
+        </dependency>
+        <!-- Creaper by tooling-server-config -->
+        <dependency>
+            <groupId>org.wildfly.extras.creaper</groupId>
+            <artifactId>creaper-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-managed</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/ConfigurationException.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/ConfigurationException.java
@@ -1,0 +1,25 @@
+package org.jboss.eap.qe.microprofile.tooling.server.configuration;
+
+/**
+ * Represents configuration related exceptions
+ */
+public class ConfigurationException extends Exception {
+
+    private static final long serialVersionUID = -4950064556540049693L;
+
+    public ConfigurationException() {
+        this("");
+    }
+
+    public ConfigurationException(String message) {
+        super(message);
+    }
+
+    public ConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ConfigurationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/arquillian/ArquillianConfigurationExtension.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/arquillian/ArquillianConfigurationExtension.java
@@ -1,0 +1,21 @@
+package org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * Extension which sets property descriptor in {@link ArquillianContainerProperties} class which is used in MP specs
+ * tests
+ */
+public class ArquillianConfigurationExtension implements RemoteLoadableExtension {
+
+    /**
+     * Registers the extension
+     *
+     * @param builder Instance of builder to be used by the registered extension
+     */
+    @Override
+    public void register(LoadableExtension.ExtensionBuilder builder) {
+        builder.observer(ArquillianDescriptorWrapper.class);
+    }
+}

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/arquillian/ArquillianContainerProperties.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/arquillian/ArquillianContainerProperties.java
@@ -1,0 +1,102 @@
+package org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian;
+
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.config.descriptor.api.ContainerDef;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
+
+import java.util.Optional;
+
+/**
+ * Provides access to Arquillian container configuration properties
+ */
+public class ArquillianContainerProperties {
+
+    private final ArquillianDescriptor arquillianDescriptor;
+
+    public static final String DEFAULT_CONTAINER_NAME = "jboss";
+    public static final String DEFAULT_MANAGEMENT_ADDRESS_VALUE = "127.0.0.1";
+    public static final String DEFAULT_MANAGEMENT_PORT_VALUE = "9990";
+    public static final String ARQ_MANAGEMENT_ADDRESS_PROPERTY_NAME = "managementAddress";
+    public static final String ARQ_MANAGEMENT_PORT_PROPERTY_NAME = "managementPort";
+
+    public ArquillianContainerProperties(ArquillianDescriptor descriptor) {
+        this.arquillianDescriptor = descriptor;
+    }
+
+    /**
+     * Retrieves definition for the given Arquillian container name
+     *
+     * @param container Name of requested container definition
+     * @return Instance of {@link ContainerDef} that describes the container
+     */
+    private Optional<ContainerDef> getNamedContainerDefinition(String container) {
+        return arquillianDescriptor.getContainers().stream()
+                .filter(c -> c.getContainerName().equals(container))
+                .findFirst();
+    }
+
+    /**
+     * Gets the value for a property for a named Arquillian container
+     *
+     * @param container The name of the container
+     * @param key       The name of the property
+     * @return The value for the requested property
+     * @throws {@link ConfigurationException} instance if no container for given name is found
+     */
+    public String getContainerProperty(String container, String key) throws ConfigurationException {
+        Optional<ContainerDef> containerDefinition = getNamedContainerDefinition(container);
+        if (!containerDefinition.isPresent()) {
+            throw new ConfigurationException(
+                    String.format("Definition for container with name [%s] was not found in arquillian.xml descriptor", container));
+        }
+        return containerDefinition.get().getContainerProperty(key);
+    }
+
+    /**
+     * Gets the value for a property of a given Arquillian container and returns the default value passed when the
+     * given property value is null or empty
+     *
+     * @param container    The name of the container
+     * @param key          The name of the property
+     * @param defaultValue The default value to be returned when the given property name is not found
+     * @return The value for the requested property or the given default value when the given property value is null or
+     * empty
+     * @throws {@link ConfigurationException} instance if no container for given name is found
+     */
+    public String getContainerProperty(String container, String key, String defaultValue) throws ConfigurationException {
+        Optional<ContainerDef> containerDefinition = getNamedContainerDefinition(container);
+        if (!containerDefinition.isPresent()) {
+            throw new ConfigurationException(
+                    String.format("Definition for container with name [%s] was not found in arquillian.xml descriptor", container));
+        }
+        String result = containerDefinition.get().getContainerProperty(key);
+        return (result == null) || result.isEmpty() ? defaultValue : result;
+    }
+
+    /**
+     * Gets the default value for the management address, which is taken from arquillian.xml configuration file
+     * <b>"127.0.0.1"</b> is returned if no value is found for "managementAddress" property.
+     *
+     * @return The default Wildfly management interface address
+     */
+    public String getDefaultManagementAddress() throws ConfigurationException {
+        return getContainerProperty(
+                DEFAULT_CONTAINER_NAME,
+                ARQ_MANAGEMENT_ADDRESS_PROPERTY_NAME,
+                DEFAULT_MANAGEMENT_ADDRESS_VALUE);
+    }
+
+    /**
+     * Gets the default value for the management port, which is taken from arquillian.xml configuration file
+     * <b>9990</b> is returned if no value is found for "managementPort" property.
+     *
+     * @return The default Wildfly management interface port
+     */
+    public int getDefaultManagementPort() throws ConfigurationException {
+        return Integer.parseInt(
+                getContainerProperty(
+                        DEFAULT_CONTAINER_NAME,
+                        ARQ_MANAGEMENT_PORT_PROPERTY_NAME,
+                        DEFAULT_MANAGEMENT_PORT_VALUE));
+    }
+}

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/arquillian/ArquillianDescriptorWrapper.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/arquillian/ArquillianDescriptorWrapper.java
@@ -1,0 +1,35 @@
+package org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian;
+
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
+
+/**
+ * Wraps Arquillian descriptor retrieval/exposure logic
+ */
+public class ArquillianDescriptorWrapper {
+
+    /**
+     * This property is initialized during Before* phase by ArquillianConfiguration extension
+     */
+    private static ArquillianDescriptor arquillianDescriptor;
+
+    public ArquillianDescriptorWrapper() {
+    }
+
+    /**
+     * Sets the {@link ArquillianDescriptorWrapper#arquillianDescriptor} field during Before* phase through
+     * ArquillianConfiguration
+     * extension
+     *
+     * @param event      {@link BeforeSuite} instance of Arquillian event the method listens to
+     * @param descriptor {@link ArquillianDescriptor} instance that will be assigned to the internal static field
+     */
+    public static void setArquillianDescriptor(@Observes BeforeSuite event, ArquillianDescriptor descriptor) {
+        arquillianDescriptor = descriptor;
+    }
+
+    public static ArquillianDescriptor getArquillianDescriptor() {
+        return arquillianDescriptor;
+    }
+}

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/creaper/ManagementClientHelper.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/creaper/ManagementClientHelper.java
@@ -1,0 +1,28 @@
+package org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper;
+
+import org.wildfly.extras.creaper.core.online.ModelNodeResult;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+
+/**
+ * Helper that provides operations to manage the CLI operations via {@link OnlineManagementClient} API.
+ */
+public class ManagementClientHelper {
+
+    /**
+     * Executes a valid CLI command through the given {@link OnlineManagementClient} instance.
+     *
+     * @param client  {@link OnlineManagementClient} instance used to execute the command
+     * @param command A valid CLI command
+     * @return {@link ModelNodeResult} instance to represent the command execution outcome
+     * @throws ManagementClientRelatedException Wraps exceptions thrown by the internal operation executed by
+     *                                          {@link OnlineManagementClient} API
+     */
+    public static ModelNodeResult executeCliCommand(OnlineManagementClient client,
+                                                    String command) throws ManagementClientRelatedException {
+        try {
+            return client.execute(command);
+        } catch (Exception e) {
+            throw new ManagementClientRelatedException(e);
+        }
+    }
+}

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/creaper/ManagementClientProvider.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/creaper/ManagementClientProvider.java
@@ -1,0 +1,33 @@
+package org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper;
+
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
+import org.wildfly.extras.creaper.core.ManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.OnlineOptions;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
+
+/**
+ * Provider for Creaper's OnlineManagementClient
+ */
+public class ManagementClientProvider {
+
+    private ManagementClientProvider() {
+    }
+
+    /**
+     * Creates {@link OnlineManagementClient} for <b>standalone</b> mode, based on {@link ArquillianContainerProperties}
+     *
+     * @param arquillianContainerProperties {@link ArquillianContainerProperties} instance to provide Arquillian
+     *                                      configuration
+     * @return Initialized {@link OnlineManagementClient} instance, don't forget to close it
+     * @throws ConfigurationException Wraps exceptions thrown by the internal operation executed by
+     *                                {@link ArquillianContainerProperties} API
+     */
+    public static OnlineManagementClient onlineStandalone(ArquillianContainerProperties arquillianContainerProperties) throws ConfigurationException {
+        return ManagementClient.onlineLazy(
+                OnlineOptions.standalone().hostAndPort(
+                        arquillianContainerProperties.getDefaultManagementAddress(),
+                        arquillianContainerProperties.getDefaultManagementPort()
+                ).build());
+    }
+}

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/creaper/ManagementClientRelatedException.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/creaper/ManagementClientRelatedException.java
@@ -1,0 +1,25 @@
+package org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper;
+
+/**
+ * Represents management client related exceptions
+ */
+public class ManagementClientRelatedException extends Exception {
+
+    private static final long serialVersionUID = -4044759360593130610L;
+
+    public ManagementClientRelatedException() {
+        this("");
+    }
+
+    public ManagementClientRelatedException(String message) {
+        super(message);
+    }
+
+    public ManagementClientRelatedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ManagementClientRelatedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/tooling-server-configuration/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/tooling-server-configuration/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianConfigurationExtension

--- a/tooling-server-configuration/src/test/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/CreaperManagementClientTest.java
+++ b/tooling-server-configuration/src/test/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/CreaperManagementClientTest.java
@@ -1,0 +1,32 @@
+package org.jboss.eap.qe.microprofile.tooling.server.configuration;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Tests Creaper integration for CLI operations.
+ * <p>
+ * {@link ManagementClientProvider} uses {@link ArquillianContainerProperties} to retrieve default configuration from Arquillian context
+ */
+@RunWith(Arquillian.class)
+public class CreaperManagementClientTest {
+
+    static ArquillianContainerProperties arquillianContainerProperties = new ArquillianContainerProperties(ArquillianDescriptorWrapper.getArquillianDescriptor());
+
+    @Test
+    public void testReloadCommand() throws IOException, ConfigurationException, TimeoutException, InterruptedException {
+        try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone(arquillianContainerProperties)) {
+            Administration admin = new Administration(client);
+            admin.reload();
+        }
+    }
+}


### PR DESCRIPTION
Following suggestions:

* https://github.com/jboss-eap-qe/eap-microprofile-test-suite/pull/47#discussion_r350145513

and

* https://github.com/jboss-eap-qe/eap-microprofile-test-suite/pull/47#pullrequestreview-322276939

to integrate Creaper _just for the use cases needed by *MP OpenAPI spec* tests at the moment_ (i.e. add and remove subsystem). 

A single integration test to verify CLI commands has been developed to cover test plan requirement and to verify Creaper integration.

- [x] Pull Request contains description for the changes
- [x] Pull Request does not include fixes for multiple issues / topics
- [x] Code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)