### PR TITLE
Add convenience method for retrieving Creaper OnlineManagementClient

### DIFF
--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/creaper/ManagementClientProvider.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/creaper/ManagementClientProvider.java
@@ -1,6 +1,7 @@
 package org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper;
 
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
 import org.wildfly.extras.creaper.core.ManagementClient;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.OnlineOptions;
@@ -12,6 +13,18 @@ import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationE
 public class ManagementClientProvider {
 
     private ManagementClientProvider() {
+    }
+
+    /**
+     * Creates {@link OnlineManagementClient} for <b>standalone</b> mode, based on {@link ArquillianContainerProperties}
+     * obtained from {@link ArquillianDescriptorWrapper}
+     *
+     * @return Initialized {@link OnlineManagementClient} instance, don't forget to close it
+     * @throws ConfigurationException Wraps exceptions thrown by the internal operation executed by
+     *                                {@link ArquillianContainerProperties} API
+     */
+    public static OnlineManagementClient onlineStandalone() throws ConfigurationException {
+        return onlineStandalone(new ArquillianContainerProperties(ArquillianDescriptorWrapper.getArquillianDescriptor()));
     }
 
     /**

--- a/tooling-server-configuration/src/test/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/CreaperManagementClientTest.java
+++ b/tooling-server-configuration/src/test/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/CreaperManagementClientTest.java
@@ -1,5 +1,8 @@
 package org.jboss.eap.qe.microprofile.tooling.server.configuration;
 
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
@@ -9,21 +12,30 @@ import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 
-import java.io.IOException;
-import java.util.concurrent.TimeoutException;
-
 /**
  * Tests Creaper integration for CLI operations.
  * <p>
- * {@link ManagementClientProvider} uses {@link ArquillianContainerProperties} to retrieve default configuration from Arquillian context
+ * {@link ManagementClientProvider} uses {@link ArquillianContainerProperties} to retrieve default configuration from Arquillian
+ * context
  */
 @RunWith(Arquillian.class)
 public class CreaperManagementClientTest {
 
-    static ArquillianContainerProperties arquillianContainerProperties = new ArquillianContainerProperties(ArquillianDescriptorWrapper.getArquillianDescriptor());
+    static ArquillianContainerProperties arquillianContainerProperties = new ArquillianContainerProperties(
+            ArquillianDescriptorWrapper.getArquillianDescriptor());
 
     @Test
-    public void testReloadCommand() throws IOException, ConfigurationException, TimeoutException, InterruptedException {
+    public void testReloadCommandWithDefaultArquillianProperties()
+            throws IOException, ConfigurationException, TimeoutException, InterruptedException {
+        try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+            Administration admin = new Administration(client);
+            admin.reload();
+        }
+    }
+
+    @Test
+    public void testReloadCommandWithProvidedArquillianContainerProperties()
+            throws IOException, ConfigurationException, TimeoutException, InterruptedException {
         try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone(arquillianContainerProperties)) {
             Administration admin = new Administration(client);
             admin.reload();


### PR DESCRIPTION
Add convenience method for retrieving Creaper OnlineManagementClient.

Please make sure your PR meets the following requirements:
- [ ] Pull Request contains description for the changes
- [ ] Pull Request does not include fixes for multiple issues / topics
- [ ] Code compiles and tests are passing
- [ ] Code is self-descriptive and/or documented
- [ ] Description of the tests scenarios is included (see #46)