### PR TITLE
Enhance Docker API + fix MalformedDockerConfigTest test

### DIFF
--- a/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/MalformedDockerConfigTest.java
+++ b/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/MalformedDockerConfigTest.java
@@ -5,8 +5,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.not;
 
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Rule;
@@ -23,6 +21,7 @@ public class MalformedDockerConfigTest {
         Docker containerWithInvalidVersion = new Docker.Builder("wildfly", "jboss/wildfly:InvalidVersion")
                 .setContainerReadyTimeout(10, TimeUnit.SECONDS) // shorten timeout as this should fail fast
                 .setContainerReadyCondition(() -> false) // it's expected that server never starts and fails fast thus return false
+                .withPortMapping("bad:mapping")
                 .build();
 
         thrown.expect(DockerException.class);
@@ -64,29 +63,14 @@ public class MalformedDockerConfigTest {
     public void testContainerReadyTimeout() throws Exception {
         Docker containerWithShortTimeout = new Docker.Builder("wildlfy", "jboss/wildfly:18.0.0.Final")
                 .setContainerReadyTimeout(2, TimeUnit.SECONDS)
-                .setContainerReadyCondition(() -> {
-                    try {
-                        URL url = new URL("http://" + "127.0.0.1:" + 9990 + "/health");
-                        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-                        connection.setRequestMethod("GET");
-
-                        return connection.getResponseMessage().contains("OK");
-                    } catch (Exception ex) {
-                        return false;
-                    }
-                })
-                .withPortMapping("8080:8080")
-                .withPortMapping("9990:9990")
-                .withCmdArg("/opt/jboss/wildfly/bin/standalone.sh")
-                .withCmdArg("-b=0.0.0.0")
-                .withCmdArg("-bmanagement=0.0.0.0")
+                .setContainerReadyCondition(() -> false) // never ready
                 .build();
 
         thrown.expect(DockerTimeoutException.class);
-        thrown.expectMessage(containsString("Container was not ready in timeout"));
+        thrown.expectMessage(containsString("Container was not ready in"));
 
         try {
-            containerWithShortTimeout.start(); // will timeout after 1 sec
+            containerWithShortTimeout.start();
         } finally {
             assertThat("DockerTimeoutException was thrown and starting container is expected to be stopped/killed. " +
                     "However this did not happen and there is still container running which is bug.",


### PR DESCRIPTION
Fix assert in MalformedDockerConfigTest

Enhance Docker API to allow specify `docker run` options. For example mapping volumes and so on. Add API for killing docker container and its restart.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains description for the changes
- [x] Pull Request does not include fixes for multiple issues / topics
- [x] Code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)