### PR TITLE
Set location of docker registry to download Wildfly images to avoid s…

### DIFF
--- a/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/DockerTest.java
+++ b/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/DockerTest.java
@@ -26,7 +26,7 @@ public class DockerTest {
     private static final int WILDFLY_TWO_EXPOSED_MANAGEMENT_PORT = 22990;
 
     @ClassRule
-    public static Docker wildFlyOne = new Docker.Builder(WILDFLY_ONE_CONTAINER_NAME, "jboss/wildfly:18.0.0.Final")
+    public static Docker wildFlyOne = new Docker.Builder(WILDFLY_ONE_CONTAINER_NAME, "registry.hub.docker.com/jboss/wildfly:18.0.0.Final")
             .setContainerReadyTimeout(2, TimeUnit.MINUTES)
             .setContainerReadyCondition(DockerTest::isWildFlyOneReady)
             .withPortMapping(WILDFLY_ONE_EXPOSED_HTTP_PORT + ":8080")
@@ -37,7 +37,7 @@ public class DockerTest {
             .build();
 
     @ClassRule
-    public static Docker wildFlyTwo = new Docker.Builder(WILDFLY_TWO_CONTAINER_NAME, "jboss/wildfly:18.0.0.Final")
+    public static Docker wildFlyTwo = new Docker.Builder(WILDFLY_TWO_CONTAINER_NAME, "registry.hub.docker.com/jboss/wildfly:18.0.0.Final")
             .setContainerReadyTimeout(2, TimeUnit.MINUTES)
             .setContainerReadyCondition(DockerTest::isWildFlyTwoReady)
             .withPortMapping(WILDFLY_TWO_EXPOSED_HTTP_PORT + ":8080")

--- a/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/MalformedDockerConfigTest.java
+++ b/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/MalformedDockerConfigTest.java
@@ -18,8 +18,8 @@ public class MalformedDockerConfigTest {
 
     @Test
     public void testFailFastWithMalformedDockerCommand() throws Exception {
-        Docker containerWithInvalidVersion = new Docker.Builder("wildfly", "jboss/wildfly:InvalidVersion")
-                .setContainerReadyTimeout(10, TimeUnit.SECONDS) // shorten timeout as this should fail fast
+        Docker containerWithInvalidVersion = new Docker.Builder("wildfly", "registry.hub.docker.com/jboss/wildfly:InvalidVersion")
+                .setContainerReadyTimeout(2, TimeUnit.SECONDS) // shorten timeout as this should fail fast
                 .setContainerReadyCondition(() -> false) // it's expected that server never starts and fails fast thus return false
                 .withPortMapping("bad:mapping")
                 .build();
@@ -33,7 +33,7 @@ public class MalformedDockerConfigTest {
 
     @Test
     public void testContainerWithHangingReadyCondition() throws Exception {
-        Docker containerWithHangingReadyCondition = new Docker.Builder("wildfly", "jboss/wildfly:18.0.0.Final")
+        Docker containerWithHangingReadyCondition = new Docker.Builder("wildfly", "registry.hub.docker.com/jboss/wildfly:18.0.0.Final")
                 .setContainerReadyTimeout(1, TimeUnit.SECONDS) // shorten timeout as this should fail fast
                 .setContainerReadyCondition(() -> { // simulate hanging isReady() condition
                     try {
@@ -61,7 +61,7 @@ public class MalformedDockerConfigTest {
 
     @Test
     public void testContainerReadyTimeout() throws Exception {
-        Docker containerWithShortTimeout = new Docker.Builder("wildlfy", "jboss/wildfly:18.0.0.Final")
+        Docker containerWithShortTimeout = new Docker.Builder("wildlfy", "registry.hub.docker.com/jboss/wildfly:18.0.0.Final")
                 .setContainerReadyTimeout(2, TimeUnit.SECONDS)
                 .setContainerReadyCondition(() -> false) // never ready
                 .build();


### PR DESCRIPTION
…earch of jboss/wildfly across all configured registries



Please make sure your PR meets the following requirements:
- [x] Pull Request contains description for the changes
- [x] Pull Request does not include fixes for multiple issues / topics
- [x] Code compiles and tests are passing
- [x] Link to passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)