### PR TITLE
Splitted modules to profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,6 @@
     <modules>
         <module>tooling-docker</module>
         <module>tooling-server-configuration</module>
-        <module>microprofile-health</module>
-        <module>microprofile-metrics</module>
-        <module>microprofile-open-api</module>
     </modules>
 
     <properties>
@@ -227,6 +224,34 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <!--module activation profiles-->
+        <profile>
+            <id>all-modules</id>
+            <modules>
+                <module>microprofile-health</module>
+                <module>microprofile-open-api</module>
+                <module>microprofile-metrics</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>mp-health</id>
+            <modules>
+                <module>microprofile-health</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>mp-open-api</id>
+            <modules>
+                <module>microprofile-open-api</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>mp-metrics</id>
+            <modules>
+                <module>microprofile-metrics</module>
+            </modules>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
     <modules>
         <module>tooling-docker</module>
         <module>tooling-server-configuration</module>
+        <module>microprofile-health</module>
+        <module>microprofile-metrics</module>
     </modules>
 
     <properties>
@@ -226,31 +228,12 @@
             </build>
         </profile>
 
-        <!--module activation profiles-->
-        <profile>
-            <id>all-modules</id>
-            <modules>
-                <module>microprofile-health</module>
-                <module>microprofile-open-api</module>
-                <module>microprofile-metrics</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>mp-health</id>
-            <modules>
-                <module>microprofile-health</module>
-            </modules>
-        </profile>
+        <!--This section contains module activation profiles. These modules are activated separately because features
+        they are testing was not yet included in released WildFly distribution.-->
         <profile>
             <id>mp-open-api</id>
             <modules>
                 <module>microprofile-open-api</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>mp-metrics</id>
-            <modules>
-                <module>microprofile-metrics</module>
             </modules>
         </profile>
     </profiles>


### PR DESCRIPTION
Created a set of profiles to allow build of individual modules.

Either run all modules with `mvn clean test -P all-modules` or use individual module profiles `mvn clean test -P mp-health`.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains description for the changes
- [x] Pull Request does not include fixes for multiple issues / topics
- [x] Code compiles and tests are passing
- [x] Link to passing job is provided
- [x] Code is self-descriptive and/or documented