### PR TITLE
Replacing jackson-databind dependency with Google Gson for JSON serialization

### DIFF
--- a/microprofile-open-api/pom.xml
+++ b/microprofile-open-api/pom.xml
@@ -61,8 +61,9 @@
             <artifactId>snakeyaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <version.org.wildfly.core>10.0.3.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.yaml.snakeyaml>1.24</version.org.yaml.snakeyaml>
-        <version.com.fasterxml.jackson.core.jackson-databind>2.9.10.1</version.com.fasterxml.jackson.core.jackson-databind>
+        <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
     </properties>
 
     <dependencyManagement>
@@ -111,9 +111,9 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${version.com.fasterxml.jackson.core.jackson-databind}</version>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${version.com.google.code.gson}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Here we're just replacing dependencies that RestAssured needs in order to serialize POJOs, see https://github.com/rest-assured/rest-assured/wiki/Usage#content-type-based-serialization.

Here's a link to a successful job run, although it's just for sanity check as Maven `mp-open-api` profile is not run by our TS test job now, so that was verified locally: https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-simple-face/7/

Please make sure your PR meets the following requirements:
- [x] Pull Request contains description for the changes
- [x] Pull Request does not include fixes for multiple issues / topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to passing job is provided