### PR TITLE
MP OpenAPI - Adding tests for MP Rest Client integration

### DIFF
--- a/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/provider/ProviderApplication.java
+++ b/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/provider/ProviderApplication.java
@@ -1,4 +1,4 @@
-package org.jboss.eap.qe.microprofile.openapi;
+package org.jboss.eap.qe.microprofile.openapi.apps.routing.provider;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
@@ -7,5 +7,5 @@ import javax.ws.rs.core.Application;
  * JAX-RS class to implement Service Routing application
  */
 @ApplicationPath("/")
-public class RestApplication extends Application {
+public class ProviderApplication extends Application {
 }

--- a/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/provider/rest/DistrictsResource.java
+++ b/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/provider/rest/DistrictsResource.java
@@ -3,7 +3,13 @@ package org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.rest;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PATCH;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -47,7 +53,8 @@ public class DistrictsResource {
     @Path("/all")
     @Produces(MediaType.APPLICATION_JSON)
     @APIResponses(value = {
-            @APIResponse(responseCode = "200", description = "All available districts", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.ARRAY, implementation = DistrictEntity.class))) })
+            @APIResponse(responseCode = "200", description = "All available districts", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(type = SchemaType.ARRAY, implementation = DistrictEntity.class)))
+    })
     @Extensions({
             @Extension(name = RoutingServiceConstants.OPENAPI_OPERATION_EXTENSION_PROXY_FQDN_NAME, value = RoutingServiceConstants.OPENAPI_OPERATION_EXTENSION_PROXY_FQDN_DEFAULT_VALUE),
             @Extension(name = "x-string-property", value = "string-value"),
@@ -59,7 +66,10 @@ public class DistrictsResource {
     })
     @Operation(summary = "Get all districts", description = "Retrieves and returns the available districts", operationId = "getAllDistricts")
     public Response getAllDistricts() {
-        return Response.ok().entity(districtService.getAll().stream().map(this::toEntity).collect(Collectors.toList())).build();
+        return Response.ok().entity(districtService.getAll().stream()
+                .map(this::toEntity)
+                .collect(Collectors.toList()))
+                .build();
     }
 
     /**

--- a/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/RouterApplication.java
+++ b/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/RouterApplication.java
@@ -1,0 +1,11 @@
+package org.jboss.eap.qe.microprofile.openapi.apps.routing.router;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * JAX-RS class to implement Local Service Router application
+ */
+@ApplicationPath("/")
+public class RouterApplication extends Application {
+}

--- a/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/model/DistrictObject.java
+++ b/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/model/DistrictObject.java
@@ -3,7 +3,12 @@ package org.jboss.eap.qe.microprofile.openapi.apps.routing.router.model;
 import java.io.Serializable;
 
 /**
- * Represents a concrete entity
+ * Represents a district entity as it is implemented by Local Service Router app - i.e. a POJO used to produce expected
+ * JSON data to Services Provider endpoints or to represent incoming JSON data for exposed mirrored services.
+ *
+ * This is to show that the Local Service provider could be implementing mirrored services without having the District
+ * interface available, while providing a compliant POJO, in fact Local Service Router could be written using different
+ * languages/tools. So this class is not - by design - implementing District interface.
  */
 public class DistrictObject implements Serializable {
 
@@ -26,27 +31,57 @@ public class DistrictObject implements Serializable {
         this.obsolete = obsolete;
     }
 
-    public Boolean getObsolete() {
-        return obsolete;
-    }
-
-    public void setObsolete(final Boolean isObsolete) {
-        this.obsolete = isObsolete;
-    }
-
+    /**
+     * Provide read access to the string that uniquely identifies the district
+     *
+     * @return String that uniquely identifies the district
+     */
     public String getCode() {
         return code;
     }
 
-    public void setCode(final String code) {
-        this.code = code;
-    }
-
+    /**
+     * Provide read access to the string that represents the district name
+     *
+     * @return String that represents the district name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Provides write access to the String value that represents the district name
+     *
+     * @param name String value to set the district name
+     */
     public void setName(final String name) {
         this.name = name;
+    }
+
+    /**
+     * Provides write access to the String value that uniquely identifies the district
+     *
+     * @param code String to set the value that uniquely identifies the district
+     */
+    public void setCode(final String code) {
+        this.code = code;
+    }
+
+    /**
+     * Provide read access to the boolean value that allows tell whether a district has been marked as obsolete
+     *
+     * @return True if the district has been marked as obsolete, False otherwise
+     */
+    public Boolean getObsolete() {
+        return obsolete;
+    }
+
+    /**
+     * Provides write access to the boolean value that allows to mark a district as obsolete
+     *
+     * @param isObsolete True if the district has to be marked as obsolete, False otherwise
+     */
+    public void setObsolete(final Boolean isObsolete) {
+        this.obsolete = isObsolete;
     }
 }

--- a/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/model/DistrictObject.java
+++ b/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/model/DistrictObject.java
@@ -1,0 +1,52 @@
+package org.jboss.eap.qe.microprofile.openapi.apps.routing.router.model;
+
+import java.io.Serializable;
+
+/**
+ * Represents a concrete entity
+ */
+public class DistrictObject implements Serializable {
+
+    private String code;
+    private String name;
+    private Boolean obsolete;
+
+    public DistrictObject() {
+        this(null, null, Boolean.FALSE);
+    }
+
+    public DistrictObject(String code, String name) {
+        this(code, name, Boolean.FALSE);
+
+    }
+
+    public DistrictObject(final String code, final String name, final Boolean obsolete) {
+        this.code = code;
+        this.name = name;
+        this.obsolete = obsolete;
+    }
+
+    public Boolean getObsolete() {
+        return obsolete;
+    }
+
+    public void setObsolete(final Boolean isObsolete) {
+        this.obsolete = isObsolete;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(final String code) {
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+}

--- a/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/rest/LocalServiceRouterInfoResource.java
+++ b/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/rest/LocalServiceRouterInfoResource.java
@@ -3,7 +3,9 @@ package org.jboss.eap.qe.microprofile.openapi.apps.routing.router.rest;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -31,11 +33,7 @@ public class LocalServiceRouterInfoResource {
             @APIResponse(responseCode = "200", description = "Local Service Provider FQDN", content = @Content(mediaType = MediaType.TEXT_PLAIN)),
             @APIResponse(responseCode = "500", description = "An error occurred while retrieving Local Service Provider FQDN") })
     @Operation(summary = "Get local service router FQDN", description = "Retrieves and returns the local service router FQDN", operationId = "getFullyQualifiedDomainName")
-    public Response getFullyQualifiedDomainName() {
-        try {
-            return Response.ok(InetAddress.getLocalHost().getHostName()).build();
-        } catch (UnknownHostException e) {
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
-        }
+    public Response getFullyQualifiedDomainName() throws UnknownHostException {
+        return Response.ok(InetAddress.getLocalHost().getHostName()).build();
     }
 }

--- a/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/rest/LocalServiceRouterInfoResource.java
+++ b/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/rest/LocalServiceRouterInfoResource.java
@@ -1,0 +1,41 @@
+package org.jboss.eap.qe.microprofile.openapi.apps.routing.router.rest;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+
+/**
+ * Rest resource exposing operations which provide information about Local Service Router, this is a "non-routed"
+ * service - i.e. only related to the Local Service Router domain
+ */
+@Path("/info")
+public class LocalServiceRouterInfoResource {
+
+    /**
+     * Returns local service router FQDN
+     *
+     * @return Response containing the local service router FQDN
+     */
+    @GET
+    @Path("/fqdn")
+    @Produces(MediaType.TEXT_PLAIN)
+    @APIResponses(value = {
+            @APIResponse(responseCode = "200", description = "Local Service Provider FQDN", content = @Content(mediaType = MediaType.TEXT_PLAIN)),
+            @APIResponse(responseCode = "500", description = "An error occurred while retrieving Local Service Provider FQDN") })
+    @Operation(summary = "Get local service router FQDN", description = "Retrieves and returns the local service router FQDN", operationId = "getFullyQualifiedDomainName")
+    public Response getFullyQualifiedDomainName() {
+        try {
+            return Response.ok(InetAddress.getLocalHost().getHostName()).build();
+        } catch (UnknownHostException e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/rest/routed/RouterDistrictsResource.java
+++ b/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/rest/routed/RouterDistrictsResource.java
@@ -1,0 +1,70 @@
+package org.jboss.eap.qe.microprofile.openapi.apps.routing.router.rest.routed;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.model.DistrictObject;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.services.DistrictServiceClient;
+
+/**
+ * Rest resource exposing Service Provider operations for districts management services - Local Service Router
+ * "routed" services must abide to the Services Provider definition
+ */
+@Path("/districts")
+public class RouterDistrictsResource {
+
+    DistrictServiceClient serviceClient;
+
+    public RouterDistrictsResource() throws URISyntaxException {
+        serviceClient = RestClientBuilder.newBuilder()
+                .baseUri(new URI("http://localhost:8080/serviceProviderDeployment"))
+                .build(DistrictServiceClient.class);
+    }
+
+    /**
+     * Returns all available districts
+     *
+     * @return Response containing the list of all available districts
+     */
+    @GET
+    @Path("/all")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getAllDistricts() {
+        return serviceClient.getAllDistricts();
+    }
+
+    /**
+     * Returns the district identified by the given code
+     *
+     * @param code String that uniquely identifies a District
+     * @param excludeObsolete Whether the found entity has to be returned when marked as obsolete
+     * @return Response containing the requested district data. HTTP 204 is returned when no item was found for the
+     *         given code or - in case the given "excludeObsolete" parameter is set to True - an element was found but is marked
+     *         as obsolete.
+     */
+    @GET
+    @Path("/{code}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getDistrictByCode(@PathParam("code") String code, @QueryParam("excludeObsolete") Boolean excludeObsolete) {
+        return serviceClient.getDistrictByCode(code, excludeObsolete);
+    }
+
+    /***
+     * Updates a district data
+     *
+     * @param {@link {@link DistrictObject}} instance carrying data to update the stored entity
+     * @return District instance representing the updated stored entity
+     */
+    @PATCH
+    @Path("/{code}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response updateDistrict(@RequestBody DistrictObject district) {
+        return serviceClient.updateDistrict(district.getCode(), district);
+    }
+}

--- a/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/rest/routed/RouterDistrictsResource.java
+++ b/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/rest/routed/RouterDistrictsResource.java
@@ -3,10 +3,19 @@ package org.jboss.eap.qe.microprofile.openapi.apps.routing.router.rest.routed;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import javax.ws.rs.*;
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PATCH;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.model.DistrictObject;
@@ -21,9 +30,19 @@ public class RouterDistrictsResource {
 
     DistrictServiceClient serviceClient;
 
-    public RouterDistrictsResource() throws URISyntaxException {
+    @Inject
+    @ConfigProperty(name = "services.provider.host")
+    String servicesProviderHost;
+    @Inject
+    @ConfigProperty(name = "services.provider.port")
+    int servicesProviderPort;
+
+    @PostConstruct
+    private void initializeRestClient() throws URISyntaxException {
         serviceClient = RestClientBuilder.newBuilder()
-                .baseUri(new URI("http://localhost:8080/serviceProviderDeployment"))
+                .baseUri(new URI(
+                        String.format(
+                                "http://%s:%d/serviceProviderDeployment", servicesProviderHost, servicesProviderPort)))
                 .build(DistrictServiceClient.class);
     }
 

--- a/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/services/DistrictServiceClient.java
+++ b/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/services/DistrictServiceClient.java
@@ -1,6 +1,12 @@
 package org.jboss.eap.qe.microprofile.openapi.apps.routing.router.services;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PATCH;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 

--- a/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/services/DistrictServiceClient.java
+++ b/microprofile-open-api/src/main/java/org/jboss/eap/qe/microprofile/openapi/apps/routing/router/services/DistrictServiceClient.java
@@ -1,0 +1,53 @@
+package org.jboss.eap.qe.microprofile.openapi.apps.routing.router.services;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.model.DistrictObject;
+
+/**
+ * Rest Client implementation to access Service Provider endpoints
+ */
+@Path("/districts")
+@RegisterRestClient
+public interface DistrictServiceClient {
+
+    /**
+     * Returns all available districts
+     *
+     * @return Response containing the list of all available districts
+     */
+    @GET
+    @Path("/all")
+    @Produces(MediaType.APPLICATION_JSON)
+    Response getAllDistricts();
+
+    /**
+     * Returns the district identified by the given code
+     *
+     * @param code String that uniquely identifies a District
+     * @param excludeObsolete Whether the found entity has to be returned when marked as obsolete
+     * @return Response containing the requested district data. HTTP 204 is returned when no item was found for the
+     *         given code or - in case the given "excludeObsolete" parameter is set to True - an element was found but is marked
+     *         as obsolete.
+     */
+    @GET
+    @Path("/{code}")
+    @Produces(MediaType.APPLICATION_JSON)
+    Response getDistrictByCode(@PathParam("code") String code, @QueryParam("excludeObsolete") Boolean excludeObsolete);
+
+    /***
+     * Updates a district data
+     *
+     * @param {@link District} instance carrying data to update the stored entity
+     * @return District instance representing the updated stored entoty
+     */
+    @PATCH
+    @Path("/{code}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response updateDistrict(@PathParam("code") String code, @RequestBody DistrictObject district);
+}

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/restclient/RestClientIntegrationTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/restclient/RestClientIntegrationTest.java
@@ -1,7 +1,9 @@
 package org.jboss.eap.qe.microprofile.openapi.integration.restclient;
 
 import static io.restassured.RestAssured.get;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.not;
 
 import java.io.IOException;
 
@@ -93,9 +95,14 @@ public class RestClientIntegrationTest {
     public static Archive<?> localServicesRouterDeployment() {
         //  OpenAPI doc here is exposing doc generated only from Local Service Provider "non-routed" JAX-RS endpoints
         //  as MP Config is used to tell MP OpenAPI to skip doc generation for exposed "routed" JAX-RS endpoints
+        //  Here we also add config properties to reach the Services Provider
         String mpConfigProperties = "mp.openapi.scan.exclude.packages=org.jboss.eap.qe.microprofile.openapi.apps.routing.router.rest.routed"
                 + "\n" +
-                "mp.openapi.scan.disable=false";
+                "mp.openapi.scan.disable=false"
+                + "\n" +
+                "services.provider.host=localhost"
+                + "\n" +
+                "services.provider.port=8080";
 
         WebArchive deployment = ShrinkWrap.create(
                 WebArchive.class, ROUTER_DEPLOYMENT_NAME + ".war")

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/restclient/RestClientIntegrationTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/restclient/RestClientIntegrationTest.java
@@ -1,0 +1,160 @@
+package org.jboss.eap.qe.microprofile.openapi.integration.restclient;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.Matchers.*;
+
+import java.io.IOException;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.eap.qe.microprofile.openapi.OpenApiDeploymentUrlProvider;
+import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.api.DistrictService;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.data.DistrictEntity;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.model.District;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.rest.DistrictsResource;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.services.InMemoryDistrictService;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.model.DistrictObject;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.rest.LocalServiceRouterInfoResource;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.rest.routed.RouterDistrictsResource;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.services.DistrictServiceClient;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientRelatedException;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+
+/**
+ * Test cases for MP OpenAPI and MP Rest Client integration
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class RestClientIntegrationTest {
+
+    private final static String PROVIDER_DEPLOYMENT_NAME = "serviceProviderDeployment";
+    private final static String ROUTER_DEPLOYMENT_NAME = "localServicesRouterDeployment";
+
+    private static String openApiUrl;
+    private static OnlineManagementClient onlineManagementClient;
+
+    @BeforeClass
+    public static void setup() throws ManagementClientRelatedException, ConfigurationException {
+        openApiUrl = OpenApiDeploymentUrlProvider.composeDefaultOpenApiUrl();
+        //  MP OpenAPI up
+        onlineManagementClient = ManagementClientProvider.onlineStandalone();
+        if (!OpenApiServerConfiguration.openapiSubsystemExists(onlineManagementClient)) {
+            OpenApiServerConfiguration.enableOpenApi(onlineManagementClient);
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws ManagementClientRelatedException, IOException {
+        //  MP OpenAPI down
+        try {
+            OpenApiServerConfiguration.disableOpenApi(onlineManagementClient);
+        } finally {
+            onlineManagementClient.close();
+        }
+    }
+
+    @Deployment(name = "serviceProviderDeployment", order = 1, testable = false)
+    public static Archive<?> serviceProviderDeployment() {
+        //  MP OpenAPI disabled on this Services Provider deployment for testing purposes, we don't want it here
+        String mpConfigProperties = "mp.openapi.extensions.enabled=false";
+        WebArchive deployment = ShrinkWrap.create(
+                WebArchive.class, PROVIDER_DEPLOYMENT_NAME + ".war")
+                .addClasses(ProviderApplication.class)
+                .addClasses(
+                        District.class,
+                        DistrictEntity.class,
+                        DistrictService.class,
+                        InMemoryDistrictService.class,
+                        DistrictsResource.class,
+                        RoutingServiceConstants.class)
+                .addAsManifestResource(new StringAsset(mpConfigProperties), "microprofile-config.properties")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return deployment;
+    }
+
+    @Deployment(name = "localServicesRouterDeployment", order = 2, testable = false)
+    public static Archive<?> localServicesRouterDeployment() {
+        //  OpenAPI doc here is exposing doc generated only from Local Service Provider "non-routed" JAX-RS endpoints
+        //  as MP Config is used to tell MP OpenAPI to skip doc generation for exposed "routed" JAX-RS endpoints
+        String mpConfigProperties = "mp.openapi.scan.exclude.packages=org.jboss.eap.qe.microprofile.openapi.apps.routing.router.rest.routed"
+                + "\n" +
+                "mp.openapi.scan.disable=false";
+
+        WebArchive deployment = ShrinkWrap.create(
+                WebArchive.class, ROUTER_DEPLOYMENT_NAME + ".war")
+                .addClasses(
+                        ProviderApplication.class,
+                        LocalServiceRouterInfoResource.class)
+                .addClasses(
+                        DistrictObject.class,
+                        RouterDistrictsResource.class,
+                        DistrictServiceClient.class)
+                .addAsManifestResource(new StringAsset(mpConfigProperties), "microprofile-config.properties")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return deployment;
+    }
+
+    /**
+     * @tpTestDetails Integration test to verify MP Rest Client usage by Local Service Router JAX-RS resource
+     * @tpPassCrit One of the Local Service Router endpoints is called to retrieve data from Service Provider,
+     *             verifying the HTTP response code and content type
+     *
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Test
+    public void testAppEndpoint() {
+        get(OpenApiDeploymentUrlProvider.composeDefaultDeploymentBaseUrl(ROUTER_DEPLOYMENT_NAME + "/districts/all"))
+                .then()
+                .statusCode(200)
+                .contentType(equalToIgnoringCase(MediaType.APPLICATION_JSON));
+    }
+
+    /**
+     * @tpTestDetails Integration test to verify that MP Rest Client integration does not affect OpenAPI generation
+     * @tpPassCrit The generated document does not contain a string which uniquely identifies one of the Service
+     *             Provider endpoints URL
+     *
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Test
+    public void testNoRestClientInterfaceAnnotationInOpenApiDoc() {
+        get(openApiUrl)
+                .then()
+                .statusCode(200)
+                .contentType(equalToIgnoringCase("application/yaml"))
+                .body(not(containsString("/districts/all:")));
+    }
+
+    /**
+     * @tpTestDetails Integration test to verify that MP Rest Client integration does not affect OpenAPI generation
+     * @tpPassCrit The generated document contains a string that uniquely identifies one of the Local Service Router
+     *             endpoints URL and that was generated from local JAX-RS resources annotation
+     *
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Test
+    public void testOpenApiDocContainsLocalServicesRouterInformation() {
+        get(openApiUrl)
+                .then()
+                .statusCode(200)
+                .contentType(equalToIgnoringCase("application/yaml"))
+                .body(containsString("fqdn"));
+    }
+}

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/model/ProgrammingModelTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/model/ProgrammingModelTest.java
@@ -16,7 +16,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiDeploymentUrlProvider;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
-import org.jboss.eap.qe.microprofile.openapi.RestApplication;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.api.DistrictService;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.data.DistrictEntity;
@@ -72,7 +72,7 @@ public class ProgrammingModelTest {
         WebArchive deployment = ShrinkWrap.create(
                 WebArchive.class,
                 String.format("%s.war", DEPLOYMENT_NAME))
-                .addClasses(RestApplication.class)
+                .addClasses(ProviderApplication.class)
                 .addClasses(
                         District.class,
                         DistrictEntity.class,

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v10/OpenApi10OnJaxRsAnnotationsTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v10/OpenApi10OnJaxRsAnnotationsTest.java
@@ -13,7 +13,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiDeploymentUrlProvider;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiTestConstants;
-import org.jboss.eap.qe.microprofile.openapi.RestApplication;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.api.DistrictService;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.data.DistrictEntity;
@@ -75,7 +75,7 @@ public class OpenApi10OnJaxRsAnnotationsTest {
         WebArchive deployment = ShrinkWrap.create(
                 WebArchive.class,
                 String.format("%s.war", DEPLOYMENT_NAME))
-                .addClasses(RestApplication.class)
+                .addClasses(ProviderApplication.class)
                 .addClasses(
                         District.class,
                         DistrictEntity.class,
@@ -204,9 +204,9 @@ public class OpenApi10OnJaxRsAnnotationsTest {
         Assert.assertNotNull("\"components/schemas\" property is null", components.get("schemas"));
 
         Map<String, Object> schemas = (Map<String, Object>) components.get("schemas");
-        Assert.assertNotNull("\"components/schemas/District\" property is null", schemas.get("District"));
+        Assert.assertNotNull("\"components/schemas/District\" property is null", schemas.get("DistrictEntity"));
 
-        Map<String, Object> responsePOJO = (Map<String, Object>) schemas.get("District");
+        Map<String, Object> responsePOJO = (Map<String, Object>) schemas.get("DistrictEntity");
         Assert.assertNotNull(responsePOJO.get("properties"));
 
         Map<String, Object> properties = (Map<String, Object>) responsePOJO.get("properties");

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v11/MicroProfileOpenApi11Test.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v11/MicroProfileOpenApi11Test.java
@@ -15,6 +15,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.eap.qe.microprofile.openapi.*;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.api.DistrictService;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.data.DistrictEntity;
@@ -76,7 +77,7 @@ public class MicroProfileOpenApi11Test {
                 WebArchive.class,
                 String.format("%s.war", DEPLOYMENT_NAME))
                 .addClasses(
-                        RestApplication.class)
+                        ProviderApplication.class)
                 .addClasses(
                         District.class,
                         DistrictEntity.class,
@@ -144,8 +145,8 @@ public class MicroProfileOpenApi11Test {
         // 1.1 the addition of the JAXRS 2.1 PATCH method
         Map<String, Object> patchMethod = (Map<String, Object>) getDistrictByCodePath.get("patch");
         Assert.assertFalse("\"/districts/{code}\" \"patch\" property is empty", patchMethod.isEmpty());
-        Assert.assertTrue("\"/districts/{code}\" \"patch\" property should have exactly 8 keys",
-                patchMethod.keySet().size() == 8);
+        Assert.assertTrue("\"/districts/{code}\" \"patch\" property should have exactly 12 keys",
+                patchMethod.keySet().size() == 12);
 
         // 1.1 @Content now supports a singular example field
         Map<String, Object> responses = (Map<String, Object>) patchMethod.get("responses");

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v11/MicroProfileOpenApi11Test.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v11/MicroProfileOpenApi11Test.java
@@ -14,7 +14,9 @@ import javax.ws.rs.core.MediaType;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.eap.qe.microprofile.openapi.*;
+import org.jboss.eap.qe.microprofile.openapi.OpenApiDeploymentUrlProvider;
+import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
+import org.jboss.eap.qe.microprofile.openapi.OpenApiTestConstants;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.api.DistrictService;
@@ -145,8 +147,8 @@ public class MicroProfileOpenApi11Test {
         // 1.1 the addition of the JAXRS 2.1 PATCH method
         Map<String, Object> patchMethod = (Map<String, Object>) getDistrictByCodePath.get("patch");
         Assert.assertFalse("\"/districts/{code}\" \"patch\" property is empty", patchMethod.isEmpty());
-        Assert.assertTrue("\"/districts/{code}\" \"patch\" property should have exactly 12 keys",
-                patchMethod.keySet().size() == 12);
+        Assert.assertEquals("\"/districts/{code}\" \"patch\" property should have exactly 12 keys",
+                patchMethod.keySet().size(), 12);
 
         // 1.1 @Content now supports a singular example field
         Map<String, Object> responses = (Map<String, Object>) patchMethod.get("responses");


### PR DESCRIPTION
Integration tests to verify MP OpenAPI and MP Rest Client, see https://download.eclipse.org/microprofile/microprofile-open-api-1.1/microprofile-openapi-spec.html#_integration_with_other_microprofile_specifications

Jenkins job run:
https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-simple-face/8
but - as said - it is just for sanity checks, as `mp-open-api` profile is not taken into account in testing job, yet.
Tests are passing locally using the following feature branch:
https://github.com/pferraro/wildfly/tree/WFLY-12313
and the following TS branch:
https://github.com/fabiobrz/eap-microprofile-test-suite/tree/integration-mp-rest-client

Maven command:
```
mvn clean verify -Djboss.home=<path_to_built_feature_branch_wildfly_home> -Pmp-open-api -pl microprofile-open-api 
```


Please make sure your PR meets the following requirements:
- [x] Pull Request contains description for the changes
- [x] Pull Request does not include fixes for multiple issues / topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)