### PR TITLE
MP Health tests update so tests do not fails

### DIFF
--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MultiDeploymentHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MultiDeploymentHealthTest.java
@@ -30,7 +30,7 @@ public class MultiDeploymentHealthTest {
     @Deployment(name = "deployment1", order = 1, testable = false)
     public static Archive<?> deployment1() {
         return ShrinkWrap.create(WebArchive.class, MultiDeploymentHealthTest.class.getSimpleName() + "-1.war")
-                .addClasses(SimplifiedHealthCheck.class)
+                .addClasses(BothHealthCheck.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/SimplifiedHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/SimplifiedHealthTest.java
@@ -17,11 +17,13 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import io.restassured.http.ContentType;
 
+@Ignore("https://issues.redhat.com/browse/WFLY-12685")
 @RunAsClient
 @RunWith(Arquillian.class)
 public class SimplifiedHealthTest {

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/SubdeploymentHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/SubdeploymentHealthTest.java
@@ -38,7 +38,7 @@ public class SubdeploymentHealthTest {
                 SubdeploymentHealthTest.class.getSimpleName() + ".ear");
 
         ear.addAsModule(ShrinkWrap.create(WebArchive.class, "dep1.war")
-                .addClasses(SimplifiedHealthCheck.class)
+                .addClasses(BothHealthCheck.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml"));
 
         ear.addAsModule(ShrinkWrap.create(JavaArchive.class, "dep2.jar")


### PR DESCRIPTION
 MP Health tests update so tests do not fails with WildFly master.

Fixes https://github.com/jboss-eap-qe/eap-microprofile-test-suite/issues/95

Job run: https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/EAP7/view/EAP7-Microprofile/job/eap-7.x-microprofile-simple-face/15

Please make sure your PR meets the following requirements:
- [x] Pull Request contains description for the changes
- [x] Pull Request does not include fixes for multiple issues / topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)