### PR TITLE
MP OpenAPI - Adding MP Config integration tests + minor fixes

### DIFF
--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/OpenApiServerConfiguration.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/OpenApiServerConfiguration.java
@@ -80,8 +80,9 @@ public class OpenApiServerConfiguration {
      *         {@link OnlineManagementClient} API
      */
     public static void enableOpenApi(OnlineManagementClient client) throws ManagementClientRelatedException {
-        if (openapiSubsystemExists(client))
+        if (openapiSubsystemExists(client)) {
             return;
+        }
         try {
             ModelNodeResult result = addOpenApiExtension(client);
             result.assertSuccess();
@@ -101,8 +102,9 @@ public class OpenApiServerConfiguration {
      *         {@link OnlineManagementClient} API
      */
     public static void disableOpenApi(OnlineManagementClient client) throws ManagementClientRelatedException {
-        if (!openapiSubsystemExists(client))
+        if (!openapiSubsystemExists(client)) {
             return;
+        }
         try {
             ModelNodeResult result = removeOpenApiSubsystem(client);
             result.assertSuccess();

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/OpenApiServerConfiguration.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/OpenApiServerConfiguration.java
@@ -80,6 +80,8 @@ public class OpenApiServerConfiguration {
      *         {@link OnlineManagementClient} API
      */
     public static void enableOpenApi(OnlineManagementClient client) throws ManagementClientRelatedException {
+        if (openapiSubsystemExists(client))
+            return;
         try {
             ModelNodeResult result = addOpenApiExtension(client);
             result.assertSuccess();
@@ -99,6 +101,8 @@ public class OpenApiServerConfiguration {
      *         {@link OnlineManagementClient} API
      */
     public static void disableOpenApi(OnlineManagementClient client) throws ManagementClientRelatedException {
+        if (!openapiSubsystemExists(client))
+            return;
         try {
             ModelNodeResult result = removeOpenApiSubsystem(client);
             result.assertSuccess();

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/cdi/IntegrationWithCDITest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/cdi/IntegrationWithCDITest.java
@@ -124,9 +124,9 @@ public class IntegrationWithCDITest {
 
         Map<String, Object> responses = (Map<String, Object>) getMethod.get("responses");
         Assert.assertNotNull("\"/contact/{id}/details\" \"response\" for GET verb and HTTP status 200 is null",
-                responses.get(200));
+                responses.get("200"));
 
-        Map<String, Object> http200Response = (Map<String, Object>) responses.get(200);
+        Map<String, Object> http200Response = (Map<String, Object>) responses.get("200");
         Assert.assertNotNull(
                 "\"/contact/{id}/details\" \"response\" for GET verb and HTTP status 200 has null \"content\" property",
                 http200Response.get("content"));

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/config/MicroprofileConfigIntegrationTests.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/config/MicroprofileConfigIntegrationTests.java
@@ -239,7 +239,7 @@ public class MicroprofileConfigIntegrationTests {
      *
      * @tpSince EAP 7.4.0.CD19
      */
-    @Ignore
+    @Ignore("https://issues.redhat.com/browse/WFWIP-289")
     @Test
     @SuppressWarnings("unchecked")
     public void testDisabledAnnotationsScanIsNotAffectingPreviouslyDeployedConfiguration() {
@@ -264,7 +264,7 @@ public class MicroprofileConfigIntegrationTests {
      *
      * @tpSince EAP 7.4.0.CD19
      */
-    @Ignore
+    @Ignore("https://issues.redhat.com/browse/WFWIP-289")
     @Test
     public void testDisabledAnnotationsScanIsNotAffectingPreviouslyDeploymentInfo() {
         String responseContent = get(openApiUrl)
@@ -285,7 +285,7 @@ public class MicroprofileConfigIntegrationTests {
      *
      * @tpSince EAP 7.4.0.CD19
      */
-    @Ignore
+    @Ignore("https://issues.redhat.com/browse/WFWIP-289")
     @Test
     @SuppressWarnings("unchecked")
     public void testDisabledAnnotationsScanIsNotAffectingPreviouslyDeploymentServerRecords() {

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/config/MicroprofileConfigIntegrationTests.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/config/MicroprofileConfigIntegrationTests.java
@@ -1,0 +1,309 @@
+package org.jboss.eap.qe.microprofile.openapi.integration.config;
+
+import static io.restassured.RestAssured.get;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.eap.qe.microprofile.openapi.OpenApiDeploymentUrlProvider;
+import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
+import org.jboss.eap.qe.microprofile.openapi.OpenApiTestConstants;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.api.DistrictService;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.data.DistrictEntity;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.model.District;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.rest.DistrictsResource;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.services.InMemoryDistrictService;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.model.DistrictObject;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.rest.LocalServiceRouterInfoResource;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.rest.routed.RouterDistrictsResource;
+import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.services.DistrictServiceClient;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientRelatedException;
+import org.jboss.eap.qe.microprofile.tooling.server.log.ModelNodeLogChecker;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Test cases for MP OpenAPI and MP Config integration
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class MicroprofileConfigIntegrationTests {
+
+    private final static String PROVIDER_DEPLOYMENT_NAME = "serviceProviderDeployment";
+    private final static String ROUTER_DEPLOYMENT_NAME = "localServicesRouterTestDeployment";
+    private final static String BADLY_CONFIGURED_ROUTER_DEPLOYMENT_NAME = "localServicesRouterBadlyConfiguredDeployment";
+    private final static String SCAN_DISABLING_ROUTER_DEPLOYMENT_NAME = "localServicesRouterScanDisablingDeployment";
+
+    static String openApiUrl, localServicesRouterTestOpenApiUrl;
+    static OnlineManagementClient onlineManagementClient;
+
+    @BeforeClass
+    public static void setup() throws ManagementClientRelatedException, ConfigurationException {
+        openApiUrl = OpenApiDeploymentUrlProvider.composeDefaultOpenApiUrl();
+        localServicesRouterTestOpenApiUrl = String.format(
+                "http://%s:%s/local/openapi",
+                OpenApiTestConstants.DEFAULT_HOST_NAME,
+                OpenApiTestConstants.DEFAULT_ENDPOINT_PORT);
+        //  MP OpenAPI up
+        onlineManagementClient = ManagementClientProvider.onlineStandalone();
+        OpenApiServerConfiguration.enableOpenApi(onlineManagementClient);
+    }
+
+    @AfterClass
+    public static void tearDown() throws ManagementClientRelatedException, IOException {
+        //  MP OpenAPI down
+        try {
+            OpenApiServerConfiguration.disableOpenApi(onlineManagementClient);
+        } finally {
+            onlineManagementClient.close();
+        }
+    }
+
+    @Deployment(name = PROVIDER_DEPLOYMENT_NAME, order = 1, testable = false)
+    public static Archive<?> serviceProviderDeployment() {
+        //  This is the Services Provider deployment with default configuration and simulates the main deployment in
+        //  the current scenario - i.e. the one that is run by Services Provider. Following deployments
+        //  are used to demonstrate advanced MP Config (and vendor extension properties) integration features.
+        WebArchive deployment = ShrinkWrap.create(
+                WebArchive.class, PROVIDER_DEPLOYMENT_NAME + ".war")
+                .addClasses(ProviderApplication.class)
+                .addClasses(
+                        District.class,
+                        DistrictEntity.class,
+                        DistrictService.class,
+                        InMemoryDistrictService.class,
+                        DistrictsResource.class,
+                        RoutingServiceConstants.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return deployment;
+    }
+
+    @Deployment(name = ROUTER_DEPLOYMENT_NAME, order = 2, testable = false)
+    public static Archive<?> localServicesRouterTestDeployment() {
+        //  OpenAPI doc here is configured for the second deployment to have a different path from the one
+        //  defined by standard spec and to replace the value for Server records with a custom (local) one.
+        //  Here we also add config properties to reach the Services Provider
+        String mpConfigProperties = "mp.openapi.scan.disable=false"
+                + "\n" +
+                "mp.openapi.servers=https://xyz.io/v1"
+                + "\n" +
+                "mp.openapi.extensions.path=/local/openapi"
+                + "\n" +
+                "services.provider.host=localhost"
+                + "\n" +
+                "services.provider.port=8080";
+
+        WebArchive deployment = ShrinkWrap.create(
+                WebArchive.class, ROUTER_DEPLOYMENT_NAME + ".war")
+                .addClasses(
+                        ProviderApplication.class,
+                        LocalServiceRouterInfoResource.class)
+                .addClasses(
+                        DistrictObject.class,
+                        RouterDistrictsResource.class,
+                        DistrictServiceClient.class)
+                .addAsManifestResource(new StringAsset(mpConfigProperties), "microprofile-config.properties")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return deployment;
+    }
+
+    @Deployment(name = BADLY_CONFIGURED_ROUTER_DEPLOYMENT_NAME, order = 3, testable = false)
+    public static Archive<?> localServicesRouterBadlyConfiguredDeployment() {
+        //  OpenAPI doc here is badly configured for the third deployment - i.e. no value is provided for a custom
+        //  path for "openapi" endpoint, in order to assess that the server is actually logging expected WARN IDs.
+        //  Here we also add config properties to reach the Services Provider
+        String mpConfigProperties = "mp.openapi.scan.disable=false"
+                + "\n" +
+                "services.provider.host=localhost"
+                + "\n" +
+                "mp.openapi.servers=https://xyz.io/v1"
+                + "\n" +
+                "services.provider.port=8080";
+
+        WebArchive deployment = ShrinkWrap.create(
+                WebArchive.class, BADLY_CONFIGURED_ROUTER_DEPLOYMENT_NAME + ".war")
+                .addClasses(
+                        ProviderApplication.class,
+                        LocalServiceRouterInfoResource.class)
+                .addClasses(
+                        DistrictObject.class,
+                        RouterDistrictsResource.class,
+                        DistrictServiceClient.class)
+                .addAsManifestResource(new StringAsset(mpConfigProperties), "microprofile-config.properties")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return deployment;
+    }
+
+    @Deployment(name = SCAN_DISABLING_ROUTER_DEPLOYMENT_NAME, order = 4, testable = false)
+    public static Archive<?> localServicesRouterScanDisablingDeployment() {
+        //  OpenAPI doc here is badly configured for the fourth deployment - i.e. OpenAPI annotations scan is disabled.
+        //  This represents a negative scenario because in situation like server reboot it must be verified that
+        //  this configuration will not affect other deployments annotations scan and doc generation in general.
+        //  The server should log a WARN to inform the user that doc generation was skipped for this deployment -
+        //  as no custom path was provided.
+        //  Here we also add config properties to reach the Services Provider
+        String mpConfigProperties = "mp.openapi.scan.disable=true"
+                //                + "\n" +
+                //                "mp.openapi.extensions.path=/disabled/openapi"
+                + "\n" +
+                "services.provider.host=localhost"
+                + "\n" +
+                "services.provider.port=8080";
+
+        WebArchive deployment = ShrinkWrap.create(
+                WebArchive.class, SCAN_DISABLING_ROUTER_DEPLOYMENT_NAME + ".war")
+                .addClasses(
+                        ProviderApplication.class,
+                        LocalServiceRouterInfoResource.class)
+                .addClasses(
+                        DistrictObject.class,
+                        RouterDistrictsResource.class,
+                        DistrictServiceClient.class)
+                .addAsManifestResource(new StringAsset(mpConfigProperties), "microprofile-config.properties")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return deployment;
+    }
+
+    /**
+     * @tpTestDetails Integration test to verify usage of MP Config extension property
+     *                {@code mp.openapi.extensions.path} by Local Service Router deployments
+     * @tpPassCrit The server is logging expected {@code WFLYMPOAI0007} message because a deployment was configured
+     *             in order to have a custom url for {@code openapi} endpoint
+     *
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Test
+    public void testWarningIsLoggedBecauseOfNonConventionalOpenApiUrl() throws ConfigurationException, IOException {
+        try (final OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+            ModelNodeLogChecker modelNodeLogChecker = new ModelNodeLogChecker(client, 100);
+            Assert.assertTrue(modelNodeLogChecker.logContains("WFLYMPOAI0007"));
+        }
+    }
+
+    /**
+     * @tpTestDetails Integration test to verify that missing MP config {@code mp.openapi.extensions.path} extension
+     *                property causes the server to log a warning about document generation being skipped for one given
+     *                deployment
+     * @tpPassCrit The server is logging expected {@code WFLYMPOAI0003} message because one deployment was not
+     *             properly configured in order to have a custom url for {@code openapi} endpoint
+     *
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Test
+    public void testWarningIsLoggedBecauseOfSkippedBadlyConfiguredDeployment() throws ConfigurationException, IOException {
+        try (final OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+            ModelNodeLogChecker modelNodeLogChecker = new ModelNodeLogChecker(client, 100);
+            Assert.assertTrue(modelNodeLogChecker.logContains("WFLYMPOAI0003"));
+        }
+    }
+
+    /**
+     * @tpTestDetails Integration test to verify usage of MP Config core property {@code mp.openapi.servers} by
+     *                Local Service Router deployments
+     * @tpPassCrit The generated OpenAPI document {@code Server Records} contents are overridden by custom value
+     *             provided through {@code mp.openapi.servers} property
+     *
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Test
+    public void testServerRecordsAreOverriddenByConfigProperty() {
+        get(localServicesRouterTestOpenApiUrl)
+                .then()
+                .statusCode(200)
+                .contentType(equalToIgnoringCase("application/yaml"))
+                .body(containsString("url: https://xyz.io/v1"));
+    }
+
+    /**
+     * @tpTestDetails Integration test to verify usage of MP Config core property {@code mp.openapi.scan.disable} by
+     *                Local Service Router deployments
+     * @tpPassCrit The generated OpenAPI document {@code paths} property contents are not empty - i.e. the main
+     *             deployment related OpenAPI document is generated properly
+     *
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Ignore
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDisabledAnnotationsScanIsNotAffectingPreviouslyDeployedConfiguration() {
+        String responseContent = get(openApiUrl)
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+        Yaml yaml = new Yaml();
+        Object yamlObject = yaml.load(responseContent);
+        Map<String, Object> yamlMap = (Map<String, Object>) yamlObject;
+
+        Map<String, Object> paths = (Map<String, Object>) yamlMap.get("paths");
+        Assert.assertFalse("\"paths\" property is empty", paths.isEmpty());
+    }
+
+    /**
+     * @tpTestDetails Integration test to verify usage of MP Config core property {@code mp.openapi.scan.disable} by
+     *                Local Service Router deployments
+     * @tpPassCrit The generated OpenAPI document {@code info} property contents are not empty - i.e. the main
+     *             deployment related OpenAPI document is generated properly
+     *
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Ignore
+    @Test
+    public void testDisabledAnnotationsScanIsNotAffectingPreviouslyDeploymentInfo() {
+        String responseContent = get(openApiUrl)
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+        Assert.assertTrue(
+                "The generated OpenAPI document \"Info\" property has a wrong value for \"title\" property",
+                responseContent.contains(String.format("title: %s.war", PROVIDER_DEPLOYMENT_NAME)));
+    }
+
+    /**
+     * @tpTestDetails Integration test to verify usage of MP Config core property {@code mp.openapi.scan.disable} by
+     *                Local Service Router deployments
+     * @tpPassCrit The generated OpenAPI document {@code servers} property contents are not empty - i.e. the main
+     *             deployment related OpenAPI document is generated properly
+     *
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Ignore
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDisabledAnnotationsScanIsNotAffectingPreviouslyDeploymentServerRecords() {
+        String responseContent = get(openApiUrl)
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+        Yaml yaml = new Yaml();
+        Object yamlObject = yaml.load(responseContent);
+        Map<String, Object> yamlMap = (Map<String, Object>) yamlObject;
+
+        List<Object> serverRecords = (List<Object>) yamlMap.get("servers");
+        Assert.assertFalse("\"servers\" property is empty", serverRecords.isEmpty());
+
+        Map<String, Object> firstServerRecord = (Map<String, Object>) serverRecords.get(0);
+        Assert.assertNotNull("Expected server record not found", firstServerRecord);
+        Assert.assertEquals("\"url\" property value is not expected",
+                firstServerRecord.get("url"), String.format("/%s", PROVIDER_DEPLOYMENT_NAME));
+    }
+}

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v10/OpenApi10OnJaxRsAnnotationsTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v10/OpenApi10OnJaxRsAnnotationsTest.java
@@ -181,9 +181,10 @@ public class OpenApi10OnJaxRsAnnotationsTest {
         Assert.assertNotNull("\"/districts/{code}\" \"responses\" for GET verb is null", getMethod.get("responses"));
 
         Map<String, Object> responses = (Map<String, Object>) getMethod.get("responses");
-        Assert.assertNotNull("\"/districts/{code}\" \"response\" for GET verb and HTTP status 200 is null", responses.get(200));
+        Assert.assertNotNull("\"/districts/{code}\" \"response\" for GET verb and HTTP status 200 is null",
+                responses.get("200"));
 
-        Map<String, Object> http200Response = (Map<String, Object>) responses.get(200);
+        Map<String, Object> http200Response = (Map<String, Object>) responses.get("200");
         Assert.assertNotNull(
                 "\"/districts/{code}\" \"response\" for GET verb and HTTP status 200 has null \"content\" property",
                 http200Response.get("content"));

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v11/MicroProfileOpenApi11Test.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v11/MicroProfileOpenApi11Test.java
@@ -154,7 +154,7 @@ public class MicroProfileOpenApi11Test {
         Map<String, Object> responses = (Map<String, Object>) patchMethod.get("responses");
         Assert.assertFalse("\"/districts/{code}\" \"responses\" for PATCH verb is empty", responses.isEmpty());
 
-        Map<String, Object> http200Response = (Map<String, Object>) responses.get(200);
+        Map<String, Object> http200Response = (Map<String, Object>) responses.get("200");
         Assert.assertFalse("\"/districts/{code}\" \"response\" for PATCH verb and HTTP status 200 is empty",
                 http200Response.isEmpty());
 


### PR DESCRIPTION
Adding MP Config integration tests and some minor fixes.
Three tests are now ignored as awaiting feedback from DEV about them:

* `testDisabledAnnotationsScanIsNotAffectingPreviouslyDeployedConfiguration`

* `testDisabledAnnotationsScanIsNotAffectingPreviouslyDeploymentInfo`

* `testDisabledAnnotationsScanIsNotAffectingPreviouslyDeploymentServerRecords`

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
* Pull Request does not include fixes for multiple issues/topics: two commits are addressing minor issues:
1. enable/disable subsystem now is checking for it to be up/down
2. data type for generated OpenAPI Responses keys changed from `int` to `String` after last feature branch update. 
- [x] Code is formatted, imports ordered, code compiles and tests are passing
* N/A Link to the passing job is provided: No job can currently handle the subsequent build of projects needed
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)