### PR TITLE
Travis CI requires install and script phase, otherwise install phase fallback command is applied

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - openjdk8
   - openjdk11
-before_script:
+install:
  - mvn -version; docker version
 script:
  - mvn -B formatter:validate impsort:check


### PR DESCRIPTION
Travis CI requires install and script phase, otherwise install phase fallback command is applied

Discovered via https://github.com/jboss-eap-qe/eap-microprofile-test-suite/pull/120 which was meant to fails but didn't.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
