### PR TITLE
microprofile-jwt module code formatting

### DIFF
--- a/microprofile-jwt/src/main/java/org/jboss/eap/qe/microprofile/jwt/testapp/jaxrs/JaxRsTestApplication.java
+++ b/microprofile-jwt/src/main/java/org/jboss/eap/qe/microprofile/jwt/testapp/jaxrs/JaxRsTestApplication.java
@@ -1,18 +1,16 @@
 package org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs;
 
-import org.eclipse.microprofile.auth.LoginConfig;
-
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
+
+import org.eclipse.microprofile.auth.LoginConfig;
 
 /**
  * Application which activates JWT subsystem using {@code org.eclipse.microprofile.auth.LoginConfig} annotation
  */
-@LoginConfig(
-        authMethod = "MP-JWT",
+@LoginConfig(authMethod = "MP-JWT",
         //"Virtual" security domain
-        realmName = "MP-JWT"
-)
+        realmName = "MP-JWT")
 @ApplicationPath("/")
 public class JaxRsTestApplication extends Application {
 

--- a/microprofile-jwt/src/main/java/org/jboss/eap/qe/microprofile/jwt/testapp/jaxrs/JwtRbacTestEndpoint.java
+++ b/microprofile-jwt/src/main/java/org/jboss/eap/qe/microprofile/jwt/testapp/jaxrs/JwtRbacTestEndpoint.java
@@ -1,21 +1,21 @@
 package org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs;
 
-import org.jboss.eap.qe.microprofile.jwt.testapp.Roles;
-
 import javax.annotation.security.DeclareRoles;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
+import org.jboss.eap.qe.microprofile.jwt.testapp.Roles;
+
 /**
  * A servlet which uses RBAC to control who can execute its methods
  */
 @Path("/rbac-endpoint")
-@DeclareRoles({Roles.MONITOR, Roles.DIRECTOR, Roles.ADMIN})
+@DeclareRoles({ Roles.MONITOR, Roles.DIRECTOR, Roles.ADMIN })
 public class JwtRbacTestEndpoint {
 
-    @RolesAllowed({Roles.MONITOR})
+    @RolesAllowed({ Roles.MONITOR })
     @GET
     @Path(Roles.MONITOR)
     public Response getResponseOnlyForMonitor() {

--- a/microprofile-jwt/src/main/java/org/jboss/eap/qe/microprofile/jwt/testapp/jaxrs/SecuredJaxRsEndpoint.java
+++ b/microprofile-jwt/src/main/java/org/jboss/eap/qe/microprofile/jwt/testapp/jaxrs/SecuredJaxRsEndpoint.java
@@ -1,13 +1,13 @@
 package org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs;
 
-import org.eclipse.microprofile.jwt.JsonWebToken;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 @Path("/secured-endpoint")
 @ApplicationScoped

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/cdi/ActivationCompatibilityTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/cdi/ActivationCompatibilityTest.java
@@ -1,6 +1,10 @@
 package org.jboss.eap.qe.microprofile.jwt.cdi;
 
-import io.restassured.RestAssured;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -8,8 +12,8 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
-import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.JaxRsTestApplication;
+import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -17,11 +21,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.net.URISyntaxException;
-import java.net.URL;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-
+import io.restassured.RestAssured;
 
 /**
  * Just verify a raw token value can be injected into a variable in an application class a compare it has expected value
@@ -45,8 +45,11 @@ public class ActivationCompatibilityTest {
         return ShrinkWrap.create(WebArchive.class)
                 .addClass(SecuredJaxRsEndpoint.class)
                 .addClass(JaxRsTestApplication.class)
-                .addAsManifestResource(ActivationCompatibilityTest.class.getClassLoader().getResource("mp-config-basic.properties"), "microprofile-config.properties")
-                .addAsManifestResource(ActivationCompatibilityTest.class.getClassLoader().getResource("pki/key.public.pem"), "key.public.pem");
+                .addAsManifestResource(
+                        ActivationCompatibilityTest.class.getClassLoader().getResource("mp-config-basic.properties"),
+                        "microprofile-config.properties")
+                .addAsManifestResource(ActivationCompatibilityTest.class.getClassLoader().getResource("pki/key.public.pem"),
+                        "key.public.pem");
     }
 
     /**

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/JoseHeaderAlgorithmTestCase.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/JoseHeaderAlgorithmTestCase.java
@@ -1,6 +1,17 @@
 package org.jboss.eap.qe.microprofile.jwt.security.keyproperties;
 
-import io.restassured.RestAssured;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.NoSuchAlgorithmException;
+import java.security.Signature;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.UUID;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -18,17 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.security.NoSuchAlgorithmException;
-import java.security.Signature;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.UUID;
-
-import static org.hamcrest.CoreMatchers.equalTo;
+import io.restassured.RestAssured;
 
 @RunAsClient
 @RunWith(Arquillian.class)
@@ -43,8 +44,10 @@ public class JoseHeaderAlgorithmTestCase {
         return ShrinkWrap.create(WebArchive.class, DEFAULT_DEPLOYMENT + ".war")
                 .addClass(SecuredJaxRsEndpoint.class)
                 .addClass(JaxRsTestApplication.class)
-                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("mp-config-basic.properties"), "microprofile-config.properties")
-                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("pki/key.public.pem"), "key.public.pem");
+                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("mp-config-basic.properties"),
+                        "microprofile-config.properties")
+                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("pki/key.public.pem"),
+                        "key.public.pem");
     }
 
     @BeforeClass
@@ -58,7 +61,7 @@ public class JoseHeaderAlgorithmTestCase {
 
     /**
      * @tpTestDetails JOSE header with {@code alg} set to {@code RS256} must be supported. Verify, such JWT is not
-     * rejected.
+     *                rejected.
      * @tpPassCrit JWT is not rejected and its raw value is returned to client.
      * @tpSince EAP 7.4.0.CD19
      */
@@ -95,7 +98,7 @@ public class JoseHeaderAlgorithmTestCase {
     }
 
     private JsonWebToken prepareJwtWithCustomJoseHeaderSignedWithRS384(final JoseHeader joseHeader, final RsaKeyTool keyTool) {
-         final String subject = "FAKE_USER";
+        final String subject = "FAKE_USER";
 
         final Instant now = Instant.now();
         final Instant later = now.plus(1, ChronoUnit.HOURS);

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/KeySizeTestCase.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/KeySizeTestCase.java
@@ -1,6 +1,11 @@
 package org.jboss.eap.qe.microprofile.jwt.security.keyproperties;
 
-import io.restassured.RestAssured;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -16,11 +21,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-
-import static org.hamcrest.CoreMatchers.equalTo;
+import io.restassured.RestAssured;
 
 @RunAsClient
 @RunWith(Arquillian.class)
@@ -36,8 +37,10 @@ public class KeySizeTestCase {
         return ShrinkWrap.create(WebArchive.class, BITS_512_KEY_DEPLOYMENT + ".war")
                 .addClass(SecuredJaxRsEndpoint.class)
                 .addClass(JaxRsTestApplication.class)
-                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("mp-config-basic.properties"), "microprofile-config.properties")
-                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("pki/key512.public.pem"), "key.public.pem");
+                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("mp-config-basic.properties"),
+                        "microprofile-config.properties")
+                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("pki/key512.public.pem"),
+                        "key.public.pem");
     }
 
     @Deployment(name = BITS_1024_KEY_DEPLOYMENT)
@@ -45,8 +48,10 @@ public class KeySizeTestCase {
         return ShrinkWrap.create(WebArchive.class, BITS_1024_KEY_DEPLOYMENT + ".war")
                 .addClass(SecuredJaxRsEndpoint.class)
                 .addClass(JaxRsTestApplication.class)
-                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("mp-config-basic.properties"), "microprofile-config.properties")
-                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("pki/key1024.public.pem"), "key.public.pem");
+                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("mp-config-basic.properties"),
+                        "microprofile-config.properties")
+                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("pki/key1024.public.pem"),
+                        "key.public.pem");
     }
 
     @Deployment(name = BITS_2048_KEY_DEPLOYMENT)
@@ -54,8 +59,10 @@ public class KeySizeTestCase {
         return ShrinkWrap.create(WebArchive.class, BITS_2048_KEY_DEPLOYMENT + ".war")
                 .addClass(SecuredJaxRsEndpoint.class)
                 .addClass(JaxRsTestApplication.class)
-                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("mp-config-basic.properties"), "microprofile-config.properties")
-                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("pki/key.public.pem"), "key.public.pem");
+                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("mp-config-basic.properties"),
+                        "microprofile-config.properties")
+                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("pki/key.public.pem"),
+                        "key.public.pem");
     }
 
     @Deployment(name = BITS_4096_KEY_DEPLOYMENT)
@@ -63,13 +70,15 @@ public class KeySizeTestCase {
         return ShrinkWrap.create(WebArchive.class, BITS_4096_KEY_DEPLOYMENT + ".war")
                 .addClass(SecuredJaxRsEndpoint.class)
                 .addClass(JaxRsTestApplication.class)
-                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("mp-config-basic.properties"), "microprofile-config.properties")
-                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("pki/key4096.public.pem"), "key.public.pem");
+                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("mp-config-basic.properties"),
+                        "microprofile-config.properties")
+                .addAsManifestResource(KeySizeTestCase.class.getClassLoader().getResource("pki/key4096.public.pem"),
+                        "key.public.pem");
     }
 
     /**
      * @tpTestDetails Test specification compatibility by authenticating against server with a token signed with a valid
-     * key 1024 bits long. Proper public key is supplied to server.
+     *                key 1024 bits long. Proper public key is supplied to server.
      * @tpPassCrit Authentication is successful and client receives raw token value in response.
      * @tpSince EAP 7.4.0.CD19
      */
@@ -87,7 +96,7 @@ public class KeySizeTestCase {
 
     /**
      * @tpTestDetails Test specification compatibility by authenticating against server with a token signed with a valid
-     * key 2048 bits long. Proper public key is supplied to server.
+     *                key 2048 bits long. Proper public key is supplied to server.
      * @tpPassCrit Authentication is successful and client receives raw token value in response.
      * @tpSince EAP 7.4.0.CD19
      */
@@ -105,7 +114,7 @@ public class KeySizeTestCase {
 
     /**
      * @tpTestDetails Test specification compatibility by authenticating against server with a token signed with a valid
-     * key 2048 bits long. Proper public key is supplied to server.
+     *                key 2048 bits long. Proper public key is supplied to server.
      * @tpPassCrit Authentication is successful and client receives raw token value in response.
      * @tpSince EAP 7.4.0.CD19
      */
@@ -123,8 +132,9 @@ public class KeySizeTestCase {
 
     /**
      * @tpTestDetails Test specification compatibility by authenticating against server with a token signed with a valid
-     * key 512 bits long. This is a negative test scenario and should not succeed since MP-JWT 1.1 supports only 1024
-     * and 2048 bits long keys. Proper public key is supplied to server.
+     *                key 512 bits long. This is a negative test scenario and should not succeed since MP-JWT 1.1 supports only
+     *                1024
+     *                and 2048 bits long keys. Proper public key is supplied to server.
      * @tpPassCrit Authentication is not successful and client receives "unauthorized" response.
      * @tpSince EAP 7.4.0.CD19
      */


### PR DESCRIPTION
microprofile-jwt module code formatting

Result of `mvn verify -DskipTests -Djboss.home=foo -Pmp-open-api,mp-jwt` command

microprofile-jwt profile has to be explicitly enabled 

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [X] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing