### PR TITLE
Expanded subsystem activation tests

### DIFF
--- a/microprofile-jwt/src/main/java/org/jboss/eap/qe/microprofile/jwt/testapp/jaxrs/NonJwtJaxRsTestApplication.java
+++ b/microprofile-jwt/src/main/java/org/jboss/eap/qe/microprofile/jwt/testapp/jaxrs/NonJwtJaxRsTestApplication.java
@@ -1,0 +1,11 @@
+package org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * Empty JAX-RS application
+ */
+@ApplicationPath("/")
+public class NonJwtJaxRsTestApplication extends Application {
+}

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/ActivationPropertiesUnsetTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/ActivationPropertiesUnsetTest.java
@@ -1,0 +1,80 @@
+package org.jboss.eap.qe.microprofile.jwt.activation;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.NonJwtJaxRsTestApplication;
+import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Set of negative tests for subsystem activation.
+ */
+@RunWith(Arquillian.class)
+public class ActivationPropertiesUnsetTest {
+
+    private static final String UNSET_AUTH_ACTIVATION_PROPERTY_DEPLOYMENT_NAME = "PROPERTIES_UNSET_DEPLOYMENT";
+    private static final String NON_JWT_AUTH_ACTIVATION_PROPERTY_DEPLOYMENT_NAME = "OTHER_VALUE_DEPLOYMENT";
+
+    @Deployment(name = UNSET_AUTH_ACTIVATION_PROPERTY_DEPLOYMENT_NAME, managed = false)
+    public static Archive<?> createDeploymentNoValue() {
+        return ShrinkWrap
+                .create(WebArchive.class,
+                        ActivationPropertiesUnsetTest.class.getSimpleName() + UNSET_AUTH_ACTIVATION_PROPERTY_DEPLOYMENT_NAME
+                                + ".war")
+                .addClass(SecuredJaxRsEndpoint.class)
+                .addClass(NonJwtJaxRsTestApplication.class)
+                .addAsManifestResource(
+                        ActivationPropertiesUnsetTest.class.getClassLoader().getResource("mp-config-basic.properties"),
+                        "microprofile-config.properties")
+                .addAsManifestResource(
+                        ActivationPropertiesUnsetTest.class.getClassLoader().getResource("pki/key.public.pem"),
+                        "key.public.pem");
+    }
+
+    @Deployment(name = NON_JWT_AUTH_ACTIVATION_PROPERTY_DEPLOYMENT_NAME, managed = false)
+    public static Archive<?> createDeploymentOtherValue() {
+        return ShrinkWrap
+                .create(WebArchive.class,
+                        ActivationPropertiesUnsetTest.class.getSimpleName() + NON_JWT_AUTH_ACTIVATION_PROPERTY_DEPLOYMENT_NAME
+                                + ".war")
+                .addClass(SecuredJaxRsEndpoint.class)
+                .addClass(NonJwtJaxRsTestApplication.class)
+                .setWebXML(ActivationPropertiesUnsetTest.class.getClassLoader().getResource("basic-auth-web.xml"))
+                .addAsManifestResource(
+                        ActivationPropertiesUnsetTest.class.getClassLoader().getResource("mp-config-basic.properties"),
+                        "microprofile-config.properties")
+                .addAsManifestResource(
+                        ActivationPropertiesUnsetTest.class.getClassLoader().getResource("pki/key.public.pem"),
+                        "key.public.pem");
+    }
+
+    /**
+     * @tpTestDetails Test that subsystem is not activated when there is not {@code MP-JWT} set as an
+     *                {@code auth-method} anywhere (both web.xml and {@code @LoginConfig} annotation).
+     * @tpPassCrit Deployment fails because classes required by deployment (MP-JWT API) are not loaded due to the fact
+     *             that the subsystem was not activated.
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Test(expected = org.jboss.arquillian.container.spi.client.container.DeploymentException.class)
+    public void testDeploymentFailsWithUnsetAuth(@ArquillianResource Deployer deployer) {
+        deployer.deploy(UNSET_AUTH_ACTIVATION_PROPERTY_DEPLOYMENT_NAME);
+    }
+
+    /**
+     * @tpTestDetails Test that subsystem is not activated when the {@code auth-method} is set to other value than
+     *                {@code MP-JWT}.
+     * @tpPassCrit Deployment fails because classes required by deployment (MP-JWT API) are not loaded due to the fact
+     *             that the subsystem was not activated.
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Test(expected = org.jboss.arquillian.container.spi.client.container.DeploymentException.class)
+    public void testDeploymentFailsAuthOtherValue(@ArquillianResource Deployer deployer) {
+        deployer.deploy(NON_JWT_AUTH_ACTIVATION_PROPERTY_DEPLOYMENT_NAME);
+    }
+}

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/AnnotationActivationCompatibilityTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/AnnotationActivationCompatibilityTest.java
@@ -1,0 +1,74 @@
+package org.jboss.eap.qe.microprofile.jwt.activation;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
+import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
+import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
+import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.JaxRsTestApplication;
+import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.restassured.RestAssured;
+
+/**
+ * Set of tests which are verifying that {@code @LoginConfig} annotation works as it should - activating the JWT
+ * subsystem when configured properly.
+ */
+@RunWith(Arquillian.class)
+public class AnnotationActivationCompatibilityTest {
+
+    private static RsaKeyTool keyTool;
+
+    @BeforeClass
+    public static void beforeClass() throws URISyntaxException {
+        final URL privateKeyUrl = AnnotationActivationCompatibilityTest.class.getClassLoader()
+                .getResource("pki/key.private.pkcs8.pem");
+        if (privateKeyUrl == null) {
+            throw new IllegalStateException("Private key wasn't found in resources!");
+        }
+        keyTool = RsaKeyTool.newKeyTool(privateKeyUrl.toURI());
+    }
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, AnnotationActivationCompatibilityTest.class.getSimpleName() + ".war")
+                .addClass(SecuredJaxRsEndpoint.class)
+                .addClass(JaxRsTestApplication.class)
+                .addAsManifestResource(
+                        AnnotationActivationCompatibilityTest.class.getClassLoader().getResource("mp-config-basic.properties"),
+                        "microprofile-config.properties")
+                .addAsManifestResource(
+                        AnnotationActivationCompatibilityTest.class.getClassLoader().getResource("pki/key.public.pem"),
+                        "key.public.pem");
+    }
+
+    /**
+     * @tpTestDetails Test that subsystem was correctly activated by using {@code @LoginConfig(authMethod = "MP-JWT",
+     *         realmName = "MP-JWT")}.
+     * @tpPassCrit Same token which was sent on server is received in response.
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Test
+    @RunAsClient
+    public void testSameTokenReceived(@ArquillianResource URL url) {
+        JsonWebToken token = new JwtHelper(keyTool, "issuer").generateProperSignedJwt();
+
+        RestAssured.given().header("Authorization", "Bearer " + token.getRawValue())
+                .when().get(url.toExternalForm() + "secured-endpoint")
+                .then().body(equalTo(token.getRawValue()));
+    }
+
+}

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/package-info.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Set of tests verifying, that subsystem activation using various methods works.
+ */
+package org.jboss.eap.qe.microprofile.jwt.activation;

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/publickeylocation/PublicKeyPropertyTestCase.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/publickeylocation/PublicKeyPropertyTestCase.java
@@ -14,7 +14,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
-import org.jboss.eap.qe.microprofile.jwt.cdi.ActivationCompatibilityTest;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.JaxRsTestApplication;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
@@ -43,7 +42,8 @@ public class PublicKeyPropertyTestCase {
 
     @BeforeClass
     public static void beforeClass() throws URISyntaxException {
-        final URL privateKeyUrl = ActivationCompatibilityTest.class.getClassLoader().getResource("pki/key.private.pkcs8.pem");
+        final URL privateKeyUrl = PublicKeyPropertyTestCase.class.getClassLoader()
+                .getResource("pki/key.private.pkcs8.pem");
         if (privateKeyUrl == null) {
             throw new IllegalStateException("Private key wasn't found in resources!");
         }
@@ -61,7 +61,8 @@ public class PublicKeyPropertyTestCase {
                 .addClass(SecuredJaxRsEndpoint.class)
                 .addClass(JaxRsTestApplication.class)
                 .addAsManifestResource(
-                        ActivationCompatibilityTest.class.getClassLoader().getResource("mp-config-pk-valid.properties"),
+                        PublicKeyPropertyTestCase.class.getClassLoader()
+                                .getResource("mp-config-pk-valid.properties"),
                         "microprofile-config.properties");
     }
 
@@ -76,7 +77,8 @@ public class PublicKeyPropertyTestCase {
                 .addClass(SecuredJaxRsEndpoint.class)
                 .addClass(JaxRsTestApplication.class)
                 .addAsManifestResource(
-                        ActivationCompatibilityTest.class.getClassLoader().getResource("mp-config-pk-invalid.properties"),
+                        PublicKeyPropertyTestCase.class.getClassLoader()
+                                .getResource("mp-config-pk-invalid.properties"),
                         "microprofile-config.properties");
     }
 
@@ -89,7 +91,7 @@ public class PublicKeyPropertyTestCase {
     @Test
     @RunAsClient
     @OperateOnDeployment(DEPLOYMENT_WITH_INVALID_KEY)
-    public void testJwkVerificationFailsWithInvalidKey(@ArquillianResource URL url) throws ConfigurationException, IOException {
+    public void testJwtVerificationFailsWithInvalidKey(@ArquillianResource URL url) throws ConfigurationException, IOException {
         final JsonWebToken token = new JwtHelper(keyTool, "issuer").generateProperSignedJwt();
 
         RestAssured.given()
@@ -108,15 +110,15 @@ public class PublicKeyPropertyTestCase {
     }
 
     /**
-     * @tpTestDetails A negative scenario where request with proper JWT is sent on server which has configured bad
-     *                public key. The server verifies the signature and authorizes user.
+     * @tpTestDetails Proper JWT is sent on server which has configured matching public key. The server verifies the
+     *                signature and authorizes user.
      * @tpPassCrit Token which was sent on server is sent back to client in response.
-     * @tpSince EAP 7.3.0.CD19
+     * @tpSince EAP 7.4.0.CD19
      */
     @Test
     @RunAsClient
     @OperateOnDeployment(DEPLOYMENT_WITH_VALID_KEY)
-    public void testJwkVerificationSucceedsWithValidKey(@ArquillianResource URL url) {
+    public void testJwtVerificationSucceedsWithValidKey(@ArquillianResource URL url) {
         final JsonWebToken token = new JwtHelper(keyTool, "issuer").generateProperSignedJwt();
 
         RestAssured.given()

--- a/microprofile-jwt/src/test/resources/activation-web.xml
+++ b/microprofile-jwt/src/test/resources/activation-web.xml
@@ -1,0 +1,11 @@
+<!--web.xml file set for activating MP-JWT subsystem-->
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+    <login-config>
+        <auth-method>MP-JWT</auth-method>
+        <realm-name>MP-JWT</realm-name>
+    </login-config>
+</web-app>

--- a/microprofile-jwt/src/test/resources/basic-auth-web.xml
+++ b/microprofile-jwt/src/test/resources/basic-auth-web.xml
@@ -1,0 +1,10 @@
+<!--web.xml file used for test deployments where BASIC auth-method is required and nothing else-->
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+    <login-config>
+        <auth-method>BASIC</auth-method>
+    </login-config>
+</web-app>


### PR DESCRIPTION
Expanded subsystem activation tests (added web.xml tests and negative test)

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] N/A Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)