### PR TITLE
StaticFilesTest - read openapi-fragment-body.yaml just once, not 2048 times

### DIFF
--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/misc/StaticFilesTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/misc/StaticFilesTest.java
@@ -207,14 +207,15 @@ public class StaticFilesTest {
             stream.forEach(s -> headerContentBuilder.append(s).append("\n"));
         }
         bigFileContents += headerContentBuilder.toString();
+        StringBuilder bodyChunkContentBuilder = new StringBuilder();
+        try (Stream<String> stream = Files.lines(Paths.get("src/test/resources/META-INF/openapi-fragment-body.yaml"),
+                StandardCharsets.UTF_8)) {
+            stream.forEach(s -> bodyChunkContentBuilder.append(s).append("\n"));
+        }
+        String bodyChunk = bodyChunkContentBuilder.toString();
         for (int i = 0; i < REPEAT_BODY_CONTENTS_ITERATIONS; i++) {
             //  n-chunk of body
-            StringBuilder bodyChunkContentBuilder = new StringBuilder();
-            try (Stream<String> stream = Files.lines(Paths.get("src/test/resources/META-INF/openapi-fragment-body.yaml"),
-                    StandardCharsets.UTF_8)) {
-                stream.forEach(s -> bodyChunkContentBuilder.append(s).append("\n"));
-            }
-            bigFileContents += bodyChunkContentBuilder.toString().replaceAll("@@ID@@", String.valueOf(i));
+            bigFileContents += bodyChunk.replaceAll("@@ID@@", String.valueOf(i));
         }
         //  footer
         StringBuilder footerContentBuilder = new StringBuilder();


### PR DESCRIPTION
StaticFilesTest - read openapi-fragment-body.yaml just once, not 2048 times
@fabiobrz fyi

Tests are not working against current master as discussed on chat, this should be trivial to review

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [N/A] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [N/A] Description of the tests scenarios is included (see #46)