### PR TITLE
Using constants for same claims across JWT tests

### DIFF
--- a/microprofile-jwt-auth-tool/src/main/java/org/jboss/eap/qe/microprofile/jwt/auth/tool/JwtDefaultClaimValues.java
+++ b/microprofile-jwt-auth-tool/src/main/java/org/jboss/eap/qe/microprofile/jwt/auth/tool/JwtDefaultClaimValues.java
@@ -1,0 +1,14 @@
+package org.jboss.eap.qe.microprofile.jwt.auth.tool;
+
+/**
+ * Dummy JWT claim values used across the testsuite
+ */
+public class JwtDefaultClaimValues {
+
+    public static final String ISSUER = "issuer";
+
+    public static final String SUBJECT = "FAKE_USER";
+
+    public static final String AUDIENCE = "microprofile-jwt-testsuite";
+
+}

--- a/microprofile-jwt-auth-tool/src/main/java/org/jboss/eap/qe/microprofile/jwt/auth/tool/JwtHelper.java
+++ b/microprofile-jwt-auth-tool/src/main/java/org/jboss/eap/qe/microprofile/jwt/auth/tool/JwtHelper.java
@@ -21,6 +21,10 @@ public final class JwtHelper {
         this.issuer = issuer;
     }
 
+    public JwtHelper(final RsaKeyTool keyTool) {
+        this(keyTool, JwtDefaultClaimValues.ISSUER);
+    }
+
     /**
      * Generates a spec compliant base64-encoded signed JWT that expires after one hour and has the claims "sub" and
      * "preferred_username" set to "FAKE_USER".
@@ -28,7 +32,7 @@ public final class JwtHelper {
      * @return a base64-encoded signed JWT token.
      */
     public JsonWebToken generateProperSignedJwt() {
-        return generateProperSignedJwt("FAKE_USER");
+        return generateProperSignedJwt(JwtDefaultClaimValues.SUBJECT);
     }
 
     /**
@@ -50,7 +54,7 @@ public final class JwtHelper {
      * @return a base64-encoded signed JWT token.
      */
     public JsonWebToken generateProperSignedJwt(final Set<String> groups) {
-        return generateProperSignedJwt("FAKE_USER", groups);
+        return generateProperSignedJwt(JwtDefaultClaimValues.SUBJECT, groups);
     }
 
     /**
@@ -69,7 +73,7 @@ public final class JwtHelper {
 
         final JwtClaims jwtClaims = new JwtClaims.Builder()
                 .jwtId(UUID.randomUUID().toString())
-                .audience("microprofile-jwt-testsuite")
+                .audience(JwtDefaultClaimValues.AUDIENCE)
                 .subject(subject)
                 .userPrincipalName(subject)
                 .issuer(this.issuer)

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/AnnotationActivationCompatibilityTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/AnnotationActivationCompatibilityTest.java
@@ -65,7 +65,7 @@ public class AnnotationActivationCompatibilityTest {
     @Test
     @RunAsClient
     public void testSameTokenReceived(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(keyTool, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(keyTool).generateProperSignedJwt();
 
         RestAssured.given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/WebXmlActivationCompatibilityTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/WebXmlActivationCompatibilityTest.java
@@ -67,7 +67,7 @@ public class WebXmlActivationCompatibilityTest {
     @Test
     @RunAsClient
     public void testSameTokenReceived(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(keyTool, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(keyTool).generateProperSignedJwt();
 
         RestAssured.given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/CorruptedJwtTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/CorruptedJwtTest.java
@@ -10,6 +10,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
+import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtDefaultClaimValues;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
 import org.jboss.eap.qe.microprofile.jwt.testapp.Endpoints;
@@ -53,7 +54,7 @@ public class CorruptedJwtTest {
 
         final RsaKeyTool keyTool = RsaKeyTool.newKeyTool(privateKeyUrl.toURI());
 
-        final JsonWebToken corruptedJsonJWT = new JwtHelper(keyTool, "issuer").generateJwtJsonCorrupted("FAKE_USER");
+        final JsonWebToken corruptedJsonJWT = new JwtHelper(keyTool).generateJwtJsonCorrupted(JwtDefaultClaimValues.SUBJECT);
 
         given().header("Authorization", "Bearer " + corruptedJsonJWT.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/JwtMinimalClaimSetTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/JwtMinimalClaimSetTest.java
@@ -16,6 +16,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtClaims;
+import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtDefaultClaimValues;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
 import org.jboss.eap.qe.microprofile.jwt.testapp.Endpoints;
@@ -37,8 +38,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class JwtMinimalClaimSetTest {
 
-    private static final String SUBJECT = "FAKE_USER";
-    private static final String ISSUER = "issuer";
+    private static final String SUBJECT = JwtDefaultClaimValues.SUBJECT;
+    private static final String ISSUER = JwtDefaultClaimValues.ISSUER;
 
     private static RsaKeyTool keyTool;
 
@@ -77,7 +78,7 @@ public class JwtMinimalClaimSetTest {
         //issuer (iss) claim intentionally missing
         final JwtClaims jwtClaims = new JwtClaims.Builder()
                 .jwtId(UUID.randomUUID().toString())
-                .audience("microprofile-jwt-testsuite")
+                .audience(JwtDefaultClaimValues.AUDIENCE)
                 .subject(SUBJECT)
                 .userPrincipalName(SUBJECT)
                 .issuedAtTime(now.getEpochSecond())
@@ -107,7 +108,7 @@ public class JwtMinimalClaimSetTest {
         //subject (sub) claim intentionally missing
         final JwtClaims jwtClaims = new JwtClaims.Builder()
                 .jwtId(UUID.randomUUID().toString())
-                .audience("microprofile-jwt-testsuite")
+                .audience(JwtDefaultClaimValues.AUDIENCE)
                 .issuer(ISSUER)
                 .userPrincipalName(SUBJECT)
                 .issuedAtTime(now.getEpochSecond())
@@ -136,7 +137,7 @@ public class JwtMinimalClaimSetTest {
         //expiration time (exp) claim intentionally missing
         final JwtClaims jwtClaims = new JwtClaims.Builder()
                 .jwtId(UUID.randomUUID().toString())
-                .audience("microprofile-jwt-testsuite")
+                .audience(JwtDefaultClaimValues.AUDIENCE)
                 .issuer(ISSUER)
                 .subject(SUBJECT)
                 .userPrincipalName(SUBJECT)
@@ -166,7 +167,7 @@ public class JwtMinimalClaimSetTest {
         //issued at (iat) claim intentionally missing
         final JwtClaims jwtClaims = new JwtClaims.Builder()
                 .jwtId(UUID.randomUUID().toString())
-                .audience("microprofile-jwt-testsuite")
+                .audience(JwtDefaultClaimValues.AUDIENCE)
                 .issuer(ISSUER)
                 .subject(SUBJECT)
                 .userPrincipalName(SUBJECT)
@@ -195,7 +196,7 @@ public class JwtMinimalClaimSetTest {
 
         //JWT ID (jti) claim intentionally missing
         final JwtClaims jwtClaims = new JwtClaims.Builder()
-                .audience("microprofile-jwt-testsuite")
+                .audience(JwtDefaultClaimValues.AUDIENCE)
                 .issuer(ISSUER)
                 .subject(SUBJECT)
                 .userPrincipalName(SUBJECT)
@@ -226,7 +227,7 @@ public class JwtMinimalClaimSetTest {
         //user principal name (upn) claim intentionally missing
         final JwtClaims jwtClaims = new JwtClaims.Builder()
                 .jwtId(UUID.randomUUID().toString())
-                .audience("microprofile-jwt-testsuite")
+                .audience(JwtDefaultClaimValues.AUDIENCE)
                 .issuer(ISSUER)
                 .subject(SUBJECT)
                 .issuedAtTime(now.getEpochSecond())
@@ -256,7 +257,7 @@ public class JwtMinimalClaimSetTest {
         //groups claim intentionally missing
         final JwtClaims jwtClaims = new JwtClaims.Builder()
                 .jwtId(UUID.randomUUID().toString())
-                .audience("microprofile-jwt-testsuite")
+                .audience(JwtDefaultClaimValues.AUDIENCE)
                 .issuer(ISSUER)
                 .subject(SUBJECT)
                 .userPrincipalName(SUBJECT)

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/CorruptedKeyTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/CorruptedKeyTest.java
@@ -67,7 +67,7 @@ public class CorruptedKeyTest {
      */
     @Test
     public void verifyErrorIsShownInLog(@ArquillianResource URL url) throws ConfigurationException, IOException {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer").generateProperSignedJwt();
+        final JsonWebToken token = new JwtHelper(keyTool).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/JoseHeaderAlgorithmTestCase.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/JoseHeaderAlgorithmTestCase.java
@@ -8,8 +8,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Signature;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.UUID;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -19,6 +18,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JoseHeader;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtClaims;
+import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtDefaultClaimValues;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
 import org.jboss.eap.qe.microprofile.jwt.testapp.Endpoints;
@@ -68,7 +68,7 @@ public class JoseHeaderAlgorithmTestCase {
      */
     @Test
     public void testRSA256algorithm(@ArquillianResource URL url) {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer").generateProperSignedJwt();
+        final JsonWebToken token = new JwtHelper(keyTool).generateProperSignedJwt();
 
         RestAssured.given()
                 .header("Authorization", "Bearer " + token.getRawValue())
@@ -99,21 +99,20 @@ public class JoseHeaderAlgorithmTestCase {
     }
 
     private JsonWebToken prepareJwtWithCustomJoseHeaderSignedWithRS384(final JoseHeader joseHeader, final RsaKeyTool keyTool) {
-        final String subject = "FAKE_USER";
+        final String subject = JwtDefaultClaimValues.SUBJECT;
 
         final Instant now = Instant.now();
         final Instant later = now.plus(1, ChronoUnit.HOURS);
 
         final JwtClaims jwtClaims = new JwtClaims.Builder()
                 .jwtId(UUID.randomUUID().toString())
-                .audience("microprofile-jwt-testsuite")
+                .audience(JwtDefaultClaimValues.AUDIENCE)
                 .subject(subject)
                 .userPrincipalName(subject)
-                .issuer("issuer")
+                .issuer(JwtDefaultClaimValues.ISSUER)
                 .issuedAtTime(now.getEpochSecond())
                 .expirationTime(later.getEpochSecond())
-                .groups(new HashSet<>(Arrays.asList("group1", "group2")))
-                .customClaim("preferred_username", subject)
+                .groups(Collections.emptySet())
                 .build();
 
         try {

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/KeySizeTestCase.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/KeySizeTestCase.java
@@ -88,7 +88,7 @@ public class KeySizeTestCase {
     public void testJwtSignedBy1024bitsKey(@ArquillianResource URL url) throws URISyntaxException {
         final RsaKeyTool rsaKeyTool = RsaKeyTool.newKeyTool(getPrivateKey("key1024.private.pkcs8.pem"));
 
-        JsonWebToken token = new JwtHelper(rsaKeyTool, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyTool).generateProperSignedJwt();
 
         RestAssured.given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -106,7 +106,7 @@ public class KeySizeTestCase {
     public void testJwtSignedBy2048bitsKey(@ArquillianResource URL url) throws URISyntaxException {
         final RsaKeyTool rsaKeyTool = RsaKeyTool.newKeyTool(getPrivateKey("key.private.pkcs8.pem"));
 
-        JsonWebToken token = new JwtHelper(rsaKeyTool, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyTool).generateProperSignedJwt();
 
         RestAssured.given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -124,7 +124,7 @@ public class KeySizeTestCase {
     public void testJwtSignedBy4096bitsKey(@ArquillianResource URL url) throws URISyntaxException {
         final RsaKeyTool rsaKeyTool = RsaKeyTool.newKeyTool(getPrivateKey("key4096.private.pkcs8.pem"));
 
-        JsonWebToken token = new JwtHelper(rsaKeyTool, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyTool).generateProperSignedJwt();
 
         RestAssured.given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -144,7 +144,7 @@ public class KeySizeTestCase {
     public void testJwtSignedBy512bitsKey(@ArquillianResource URL url) throws URISyntaxException {
         final RsaKeyTool rsaKeyTool = RsaKeyTool.newKeyTool(getPrivateKey("key512.private.pkcs8.pem"));
 
-        final JsonWebToken token = new JwtHelper(rsaKeyTool, "issuer").generateProperSignedJwt();
+        final JsonWebToken token = new JwtHelper(rsaKeyTool).generateProperSignedJwt();
 
         RestAssured.given()
                 .header("Authorization", "Bearer " + token.getRawValue())

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyselection/MultipleConfiguredPublicKeysSelectionLocationPropTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyselection/MultipleConfiguredPublicKeysSelectionLocationPropTest.java
@@ -81,7 +81,7 @@ public class MultipleConfiguredPublicKeysSelectionLocationPropTest {
     @Test
     @OperateOnDeployment(DEPLOYMENT_WITH_JSON_JWKS_LOCATION_PROPERTY)
     public void testJwtSignedByOrangeKeyJsonPk(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(rsaKeyToolOrange, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyToolOrange).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -100,7 +100,7 @@ public class MultipleConfiguredPublicKeysSelectionLocationPropTest {
     @Test
     @OperateOnDeployment(DEPLOYMENT_WITH_JSON_JWKS_LOCATION_PROPERTY)
     public void testJwtSignedByBlueKeyJsonPk(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(rsaKeyToolBlue, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyToolBlue).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -120,7 +120,7 @@ public class MultipleConfiguredPublicKeysSelectionLocationPropTest {
     @Test
     @OperateOnDeployment(DEPLOYMENT_WITH_JSON_JWKS_LOCATION_PROPERTY)
     public void testJwtSignedByPinkKeyJsonPk(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(rsaKeyToolPink, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyToolPink).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -138,7 +138,7 @@ public class MultipleConfiguredPublicKeysSelectionLocationPropTest {
     @Test
     @OperateOnDeployment(DEPLOYMENT_WITH_BASE64_JWKS_LOCATION_PROPERTY)
     public void testJwtSignedByOrangeKeyBase64(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(rsaKeyToolOrange, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyToolOrange).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -157,7 +157,7 @@ public class MultipleConfiguredPublicKeysSelectionLocationPropTest {
     @Test
     @OperateOnDeployment(DEPLOYMENT_WITH_BASE64_JWKS_LOCATION_PROPERTY)
     public void testJwtSignedByBlueKeyBase64(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(rsaKeyToolBlue, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyToolBlue).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -177,7 +177,7 @@ public class MultipleConfiguredPublicKeysSelectionLocationPropTest {
     @Test
     @OperateOnDeployment(DEPLOYMENT_WITH_BASE64_JWKS_LOCATION_PROPERTY)
     public void testJwtSignedByPinkKeyBase64Pk(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(rsaKeyToolPink, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyToolPink).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyselection/MultipleConfiguredPublicKeysSelectionTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyselection/MultipleConfiguredPublicKeysSelectionTest.java
@@ -103,7 +103,7 @@ public class MultipleConfiguredPublicKeysSelectionTest {
     @Test
     @OperateOnDeployment(DEPLOYMENT_WITH_JSON_JWKS)
     public void testJwtSignedByOrangeKeyJsonPk(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(rsaKeyToolOrange, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyToolOrange).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -122,7 +122,7 @@ public class MultipleConfiguredPublicKeysSelectionTest {
     @Test
     @OperateOnDeployment(DEPLOYMENT_WITH_JSON_JWKS)
     public void testJwtSignedByBlueKeyJsonPk(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(rsaKeyToolBlue, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyToolBlue).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -142,7 +142,7 @@ public class MultipleConfiguredPublicKeysSelectionTest {
     @Test
     @OperateOnDeployment(DEPLOYMENT_WITH_JSON_JWKS)
     public void testJwtSignedByPinkKeyJsonPk(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(rsaKeyToolPink, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyToolPink).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -160,7 +160,7 @@ public class MultipleConfiguredPublicKeysSelectionTest {
     @Test
     @OperateOnDeployment(DEPLOYMENT_WITH_BASE64_JWKS)
     public void testJwtSignedByOrangeKeyBase64(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(rsaKeyToolOrange, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyToolOrange).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -179,7 +179,7 @@ public class MultipleConfiguredPublicKeysSelectionTest {
     @Test
     @OperateOnDeployment(DEPLOYMENT_WITH_BASE64_JWKS)
     public void testJwtSignedByBlueKeyBase64(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(rsaKeyToolBlue, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyToolBlue).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -199,7 +199,7 @@ public class MultipleConfiguredPublicKeysSelectionTest {
     @Test
     @OperateOnDeployment(DEPLOYMENT_WITH_BASE64_JWKS)
     public void testJwtSignedByPinkKeyBase64Pk(@ArquillianResource URL url) {
-        JsonWebToken token = new JwtHelper(rsaKeyToolPink, "issuer").generateProperSignedJwt();
+        JsonWebToken token = new JwtHelper(rsaKeyToolPink).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/publickeylocation/PublicKeyLocationPropertyTestCase.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/publickeylocation/PublicKeyLocationPropertyTestCase.java
@@ -114,7 +114,7 @@ public class PublicKeyLocationPropertyTestCase {
      */
     @Test
     public void testPublicKeyObtainedFromHttp(@ArquillianResource @OperateOnDeployment(DEPLOYMENT_KEY_FROM_HTTP) URL url) {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer").generateProperSignedJwt();
+        final JsonWebToken token = new JwtHelper(keyTool).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -131,7 +131,7 @@ public class PublicKeyLocationPropertyTestCase {
     @Test
     public void testPublicKeyObtainedFromHttpInvalidUrl(
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_KEY_FROM_HTTP_INVALID) URL url) {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer").generateProperSignedJwt();
+        final JsonWebToken token = new JwtHelper(keyTool).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -147,7 +147,7 @@ public class PublicKeyLocationPropertyTestCase {
      */
     @Test
     public void testPublicKeyObtainedFromFile(@ArquillianResource @OperateOnDeployment(DEPLOYMENT_KEY_FROM_FILE) URL url) {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer").generateProperSignedJwt();
+        final JsonWebToken token = new JwtHelper(keyTool).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)
@@ -164,7 +164,7 @@ public class PublicKeyLocationPropertyTestCase {
     @Test
     public void testPublicKeyObtainedFromFileInvalidUrl(
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_KEY_FROM_FILE_INVALID) URL url) {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer").generateProperSignedJwt();
+        final JsonWebToken token = new JwtHelper(keyTool).generateProperSignedJwt();
 
         given().header("Authorization", "Bearer " + token.getRawValue())
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/publickeylocation/PublicKeyPropertyTestCase.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/publickeylocation/PublicKeyPropertyTestCase.java
@@ -89,7 +89,7 @@ public class PublicKeyPropertyTestCase {
     @RunAsClient
     @OperateOnDeployment(DEPLOYMENT_WITH_INVALID_KEY)
     public void testJwtVerificationFailsWithInvalidKey(@ArquillianResource URL url) throws ConfigurationException, IOException {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer").generateProperSignedJwt();
+        final JsonWebToken token = new JwtHelper(keyTool).generateProperSignedJwt();
 
         RestAssured.given()
                 .header("Authorization", "Bearer " + token.getRawValue())
@@ -110,7 +110,7 @@ public class PublicKeyPropertyTestCase {
     @RunAsClient
     @OperateOnDeployment(DEPLOYMENT_WITH_VALID_KEY)
     public void testJwtVerificationSucceedsWithValidKey(@ArquillianResource URL url) {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer").generateProperSignedJwt();
+        final JsonWebToken token = new JwtHelper(keyTool).generateProperSignedJwt();
 
         RestAssured.given()
                 .header("Authorization", "Bearer " + token.getRawValue())

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/rbac/RolesAllowedRbacTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/rbac/RolesAllowedRbacTest.java
@@ -71,7 +71,7 @@ public class RolesAllowedRbacTest {
      */
     @Test
     public void monitorAccessMonitorPath(@ArquillianResource URL url) {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer")
+        final JsonWebToken token = new JwtHelper(keyTool)
                 .generateProperSignedJwt(Collections.singleton(Roles.MONITOR));
 
         given().header("Authorization", "Bearer " + token.getRawValue())
@@ -89,7 +89,7 @@ public class RolesAllowedRbacTest {
      */
     @Test
     public void monitorAccessAdminPath(@ArquillianResource URL url) {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer")
+        final JsonWebToken token = new JwtHelper(keyTool)
                 .generateProperSignedJwt(Collections.singleton(Roles.MONITOR));
 
         given().header("Authorization", "Bearer " + token.getRawValue())
@@ -108,7 +108,7 @@ public class RolesAllowedRbacTest {
      */
     @Test
     public void noRoleAccessAdminPath(@ArquillianResource URL url) {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer")
+        final JsonWebToken token = new JwtHelper(keyTool)
                 .generateProperSignedJwt(Collections.emptySet());
 
         given().header("Authorization", "Bearer " + token.getRawValue())
@@ -127,7 +127,7 @@ public class RolesAllowedRbacTest {
      */
     @Test
     public void monitorAccessAdminDirectorPath(@ArquillianResource URL url) {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer")
+        final JsonWebToken token = new JwtHelper(keyTool)
                 .generateProperSignedJwt(Collections.singleton(Roles.MONITOR));
 
         given().header("Authorization", "Bearer " + token.getRawValue())
@@ -146,7 +146,7 @@ public class RolesAllowedRbacTest {
      */
     @Test
     public void adminAccessAdminDirectorPath(@ArquillianResource URL url) {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer")
+        final JsonWebToken token = new JwtHelper(keyTool)
                 .generateProperSignedJwt(Collections.singleton(Roles.ADMIN));
 
         given().header("Authorization", "Bearer " + token.getRawValue())
@@ -164,7 +164,7 @@ public class RolesAllowedRbacTest {
      */
     @Test
     public void monitorAccessDenyAllPath(@ArquillianResource URL url) {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer")
+        final JsonWebToken token = new JwtHelper(keyTool)
                 .generateProperSignedJwt(Collections.singleton(Roles.MONITOR));
 
         given().header("Authorization", "Bearer " + token.getRawValue())
@@ -196,7 +196,7 @@ public class RolesAllowedRbacTest {
      */
     @Test
     public void adminAccessPermitAllPath(@ArquillianResource URL url) {
-        final JsonWebToken token = new JwtHelper(keyTool, "issuer")
+        final JsonWebToken token = new JwtHelper(keyTool)
                 .generateProperSignedJwt(Collections.singleton(Roles.ADMIN));
 
         given().header("Authorization", "Bearer " + token.getRawValue())


### PR DESCRIPTION
There are repeating values set to claims across JWT tests. I made these values constants.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- N/A Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)