### PR TITLE
Copy jboss as to target and use jboss.dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
  - mvn -version; docker version
 script:
  - mvn -B formatter:validate impsort:check
- - mvn -B verify -DskipTests -Djboss.home=foo
+ - mvn -B verify -DskipTests -Djboss.dist=foo
 cache:
  directories:
   - $HOME/.m2

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
                     WF_RELATIVE_PATH=`find wildfly/dist/target -mindepth 1 -maxdepth 1 -type d | grep "target/wildfly"`
                     WF_HOME=${PWD}/${WF_RELATIVE_PATH}
                     cd eap-microprofile-test-suite
-                    ./mvnw -B clean verify -Denforcer.skip=true -Djboss.home=$WF_HOME
+                    ./mvnw -B clean verify -Denforcer.skip=true -Djboss.dist=$WF_HOME
                 '''
             }
         }        

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ mvn clean verify -Darquillian.deploymentExportPath=target/deployments/
 
 ## Run one module against custom build
 ```
-mvn clean verify -pl microprofile-health -Djboss.home=/Users/rsvoboda/Downloads/wildfly-18.0.0.Final
+mvn clean verify -pl microprofile-health -Djboss.dist=/Users/rsvoboda/Downloads/wildfly-18.0.0.Final
 
-./mvnw clean verify -pl microprofile-health -Djboss.home=/Users/rsvoboda/Downloads/wildfly-18.0.0.Final
+./mvnw clean verify -pl microprofile-health -Djboss.dist=/Users/rsvoboda/Downloads/wildfly-18.0.0.Final
 ```
 
 ## Run one module against running server
@@ -49,11 +49,11 @@ Please note `allowConnectingToRunningServer` property in `arquillian.xml`.
 - Trigger build by `Build Now` button - NOTE FIRST RUN WILL FAIL DUE TO ISSUES <https://issues.jenkins-ci.org/browse/JENKINS-40574/> <https://issues.jenkins-ci.org/browse/JENKINS-41929> but all the subsequent runs will work
 
 ## Quick compilation of the code
-Can be used to ensure code changes are compilable, `-Djboss.home=foo` is workaround to skip unpacking of WildFly zip.
+Can be used to ensure code changes are compilable, `-Djboss.dist=foo` is workaround to skip unpacking of WildFly zip.
 ```
-mvn clean verify -DskipTests -DskipITs -Djboss.home=foo
+mvn clean verify -DskipTests -DskipITs -Djboss.dist=foo
 
-./mvnw clean verify -DskipTests -DskipITs -Djboss.home=foo
+./mvnw clean verify -DskipTests -DskipITs -Djboss.dist=foo
 ```
 
 ## Zip distribution bundle

--- a/arquillian.xml
+++ b/arquillian.xml
@@ -4,7 +4,7 @@
 
     <container qualifier="jboss" default="true" >
         <configuration>
-            <property name="jbossHome">${jboss.home}</property>
+            <property name="jbossHome">${basedir}/target/jboss-as</property>
             <property name="javaVmArguments">-server -Xms64m -Xmx512m</property>
             <property name="serverConfig">standalone.xml</property>
             <property name="managementAddress">127.0.0.1</property>

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,7 @@
                     <systemPropertyVariables>
                         <jboss.home>${jboss.home}</jboss.home>
                         <arquillian.xml>${maven.multiModuleProjectDirectory}/arquillian.xml</arquillian.xml>
+                        <module.path>${jboss.modules.path}</module.path>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -212,12 +213,68 @@
 
     <profiles>
         <profile>
-            <id>download-wildfly</id>
+            <id>copy-wildfly</id>
             <activation>
-                <property><name>!jboss.home</name></property>
+                <property>
+                    <name>jboss.dist</name>
+                </property>
             </activation>
             <properties>
                 <jboss.home>${basedir}/target/jboss-as</jboss.home>
+                <jboss.modules.path>${jboss.dist}/modules</jboss.modules.path>
+            </properties>
+            <build>
+                <plugins>
+                    <!--
+                      A build of target/wildfly which is shared by all modules.
+                      Modules and bundles are not copied as they are read-only (see surefire props).
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions combine.children="append">
+                            <!-- Copy the AS into current_submodule/target/jboss-as . This is executed recursively in submodules. -->
+                            <execution>
+                                <id>ts.copy-wildfly</id>
+                                <inherited>true</inherited>
+                                <phase>generate-test-resources</phase>
+                                <goals><goal>copy-resources</goal></goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/jboss-as</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>${jboss.dist}</directory>
+                                            <excludes>
+                                                <exclude>bin/client/</exclude>
+                                                <exclude>bin/*.jar</exclude>
+                                                <exclude>bin/*.sh</exclude>
+                                                <exclude>bin/*.bat</exclude>
+                                                <exclude>bin/*.ps1</exclude>
+                                                <exclude>docs/</exclude>
+                                                <exclude>modules/</exclude>
+                                                <exclude>welcome-content/*.png</exclude>
+                                                <exclude>standalone/data</exclude>
+                                                <exclude>standalone/log</exclude>
+                                                <exclude>standalone/tmp</exclude>
+                                            </excludes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>download-wildfly</id>
+            <activation>
+                <property><name>!jboss.dist</name></property>
+            </activation>
+            <properties>
+                <jboss.home>${basedir}/target/jboss-as</jboss.home>
+                <jboss.modules.path>${basedir}/target/jboss-as/modules</jboss.modules.path>
             </properties>
             <build>
                 <plugins>

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/ModuleUtil.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/ModuleUtil.java
@@ -81,7 +81,8 @@ public class ModuleUtil {
         }
 
         /**
-         * Execute the operation on {@param client}. ENV property {@code JBOSS_HOME} must be set.
+         * Execute the operation on {@param client}.
+         * System property {@code module.path} must be set (should be set in pom.xml).
          */
         public void executeOn(OnlineManagementClient client) throws IOException, CliException {
             StringBuilder cmd = new StringBuilder("module add");
@@ -94,6 +95,7 @@ public class ModuleUtil {
             Joiner resourcesJoiner = Joiner.on(File.pathSeparatorChar);
             char pathSeparatorChar = File.pathSeparatorChar;
             cmd.append(" --resource-delimiter=").append(pathSeparatorChar);
+            cmd.append(" --module-root-dir=").append(System.getProperty("module.path"));
 
             if (!this.resources.isEmpty()) {
                 cmd.append(" --resources=").append(resourcesJoiner
@@ -115,7 +117,7 @@ public class ModuleUtil {
          * Execute the operation on {@param client}. ENV property {@code JBOSS_HOME} must be set.
          */
         public void executeOn(OnlineManagementClient client) throws IOException, CliException {
-            client.executeCli("module remove --name=" + name);
+            client.executeCli("module remove --name=" + name + " --module-root-dir=" + System.getProperty("module.path"));
         }
     }
 }

--- a/tooling-server-configuration/src/test/java/org/jboss/eap/qe/microprofile/tooling/server/AddRemoveModuleTest.java
+++ b/tooling-server-configuration/src/test/java/org/jboss/eap/qe/microprofile/tooling/server/AddRemoveModuleTest.java
@@ -18,7 +18,6 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.CommandFailedException;
 import org.wildfly.extras.creaper.core.online.CliException;
-import org.wildfly.extras.creaper.core.online.ModelNodeResult;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.xml.sax.SAXException;
 
@@ -51,9 +50,9 @@ public class AddRemoveModuleTest {
                 .executeOn(client);
 
         // verify that module was added
-        File asRoot = new File(getPathToAs());
+        File modulesRoot = new File(System.getProperty("module.path"));
 
-        File module = new File(asRoot, "modules" + File.separator + TEST_MODULE_NAME.replaceAll("\\.", File.separator));
+        File module = new File(modulesRoot, TEST_MODULE_NAME.replaceAll("\\.", File.separator));
         assertTrue("Module " + module.getAbsolutePath() + " should exist on path", module.exists());
 
         File moduleTestJar1 = new File(module, "main" + File.separator + "testJar1.jar");
@@ -69,11 +68,5 @@ public class AddRemoveModuleTest {
 
         // verify that module was removed
         assertFalse("Module shouldn't exist on path " + module.getAbsolutePath(), module.exists());
-    }
-
-    private String getPathToAs() throws IOException, CliException {
-        ModelNodeResult result = client.execute(":resolve-expression(expression=${jboss.home.dir})");
-        result.assertSuccess("Cannot resolve jboss.home.dir");
-        return result.stringValue();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/jboss-eap-qe/eap-microprofile-test-suite/issues/129

tests pass

run with `-Djboss.dist`
```
[INFO] Test suite for MicroProfile on WF/EAP .............. SUCCESS [  1.434 s]
[INFO] tooling-server-configuration ....................... SUCCESS [ 12.922 s]
[INFO] microprofile-health ................................ SUCCESS [ 36.988 s]
[INFO] microprofile-metrics ............................... SUCCESS [ 27.071 s]
[INFO] server-utilities ................................... SUCCESS [  3.200 s]
[INFO] microprofile-jwt-auth-tool ......................... SUCCESS [  0.235 s]
```

run without `-Djboss.dist` - WildFly is downloaded
```
[INFO] Test suite for MicroProfile on WF/EAP .............. SUCCESS [  3.801 s]
[INFO] tooling-server-configuration ....................... SUCCESS [ 12.562 s]
```
Other modules expect newer wildfly than defined in profile downloading WildFly

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)