### PR TITLE
Adding MicroProfileServerSetupTask 

### DIFF
--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/arquillian/MicroProfileServerSetupTask.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/arquillian/MicroProfileServerSetupTask.java
@@ -1,0 +1,25 @@
+package org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+
+/**
+ * Defines the contract needed to implement custom {@code setup} {@code tearDown} methods for server configuration using
+ * Arquillian provided lifecycle but ignoring the injected {@code managementClient} and {@code containerId} parameters
+ * which are injected in {@link ServerSetupTask}.
+ */
+public interface MicroProfileServerSetupTask extends ServerSetupTask {
+    @Override
+    default public void setup(ManagementClient managementClient, String containerId) throws Exception {
+        setup();
+    }
+
+    void setup() throws Exception;
+
+    @Override
+    default public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+        tearDown();
+    }
+
+    void tearDown() throws Exception;
+}


### PR DESCRIPTION
Interface to be used in order to solve intermittent failures due to Creaper reconnecting the wrapped client

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- N/A Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)