### PR TITLE
Fixing server setup

### DIFF
--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/AcceptHeadersAndFormatParameterInteractionTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/AcceptHeadersAndFormatParameterInteractionTest.java
@@ -14,8 +14,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
@@ -25,6 +23,7 @@ import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.model.Distric
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.rest.DistrictsResource;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.services.InMemoryDistrictService;
 import org.jboss.eap.qe.microprofile.openapi.v10.OpenApi10OnJaxRsAnnotationsTest;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -32,6 +31,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 
 /**
  * Test cases to verify negative scenario in which "Accept" HTTP header and {@code format} query parameter are
@@ -61,16 +61,20 @@ public class AcceptHeadersAndFormatParameterInteractionTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    static class OpenApiExtensionSetup implements ServerSetupTask {
+    static class OpenApiExtensionSetup implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.enableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void setup() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.enableOpenApi(client);
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.disableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.disableOpenApi(client);
+            }
         }
     }
 

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/HybridDocumentationTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/HybridDocumentationTest.java
@@ -17,8 +17,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
@@ -37,6 +35,7 @@ import org.jboss.eap.qe.microprofile.openapi.model.OpenApiModelReader;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientRelatedException;
 import org.jboss.shrinkwrap.api.Archive;
@@ -147,16 +146,20 @@ public class HybridDocumentationTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    static class OpenApiExtensionSetup implements ServerSetupTask {
+    static class OpenApiExtensionSetup implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.enableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void setup() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.enableOpenApi(client);
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.disableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.disableOpenApi(client);
+            }
         }
     }
 

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/JWTSecurityAnnotationsTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/JWTSecurityAnnotationsTest.java
@@ -15,8 +15,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
@@ -33,6 +31,7 @@ import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.services.Distri
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientRelatedException;
 import org.jboss.shrinkwrap.api.Archive;
@@ -124,16 +123,20 @@ public class JWTSecurityAnnotationsTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    static class OpenApiExtensionSetup implements ServerSetupTask {
+    static class OpenApiExtensionSetup implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.enableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void setup() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.enableOpenApi(client);
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.disableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.disableOpenApi(client);
+            }
         }
     }
 

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/misc/DisablePropertiesTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/misc/DisablePropertiesTest.java
@@ -6,8 +6,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
@@ -27,6 +25,7 @@ import org.jboss.eap.qe.microprofile.openapi.model.OpenApiModelReader;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientRelatedException;
 import org.jboss.eap.qe.microprofile.tooling.server.log.ModelNodeLogChecker;
@@ -130,16 +129,20 @@ public class DisablePropertiesTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    static class OpenApiExtensionSetup implements ServerSetupTask {
+    static class OpenApiExtensionSetup implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.enableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void setup() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.enableOpenApi(client);
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.disableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.disableOpenApi(client);
+            }
         }
     }
 

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/misc/ServerContextRootTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/misc/ServerContextRootTest.java
@@ -19,8 +19,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
@@ -40,6 +38,7 @@ import org.jboss.eap.qe.microprofile.openapi.model.OpenApiModelReader;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientRelatedException;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -141,16 +140,20 @@ public class ServerContextRootTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    static class OpenApiExtensionSetup implements ServerSetupTask {
+    static class OpenApiExtensionSetup implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.enableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void setup() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.enableOpenApi(client);
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.disableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.disableOpenApi(client);
+            }
         }
     }
 

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/misc/StaticFilesTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/advanced/misc/StaticFilesTest.java
@@ -20,8 +20,6 @@ import org.jboss.arquillian.container.test.api.Testable;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
@@ -40,6 +38,7 @@ import org.jboss.eap.qe.microprofile.openapi.model.OpenApiModelReader;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientRelatedException;
 import org.jboss.shrinkwrap.api.Archive;
@@ -241,16 +240,20 @@ public class StaticFilesTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    static class OpenApiExtensionSetup implements ServerSetupTask {
+    static class OpenApiExtensionSetup implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.enableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void setup() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.enableOpenApi(client);
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.disableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.disableOpenApi(client);
+            }
         }
     }
 

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/cdi/IntegrationWithCDITest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/cdi/IntegrationWithCDITest.java
@@ -13,11 +13,10 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.RouterApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.rest.legacy.Contact;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -26,6 +25,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.yaml.snakeyaml.Yaml;
 
 /**
@@ -44,16 +44,20 @@ public class IntegrationWithCDITest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    static class OpenApiExtensionSetup implements ServerSetupTask {
+    static class OpenApiExtensionSetup implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.enableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void setup() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.enableOpenApi(client);
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.disableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.disableOpenApi(client);
+            }
         }
     }
 

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/config/MicroprofileConfigIntegrationTests.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/config/MicroprofileConfigIntegrationTests.java
@@ -16,8 +16,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
@@ -34,6 +32,7 @@ import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.services.Distri
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientRelatedException;
 import org.jboss.eap.qe.microprofile.tooling.server.log.ModelNodeLogChecker;
@@ -181,16 +180,20 @@ public class MicroprofileConfigIntegrationTests {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    static class OpenApiExtensionSetup implements ServerSetupTask {
+    static class OpenApiExtensionSetup implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.enableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void setup() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.enableOpenApi(client);
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.disableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.disableOpenApi(client);
+            }
         }
     }
 

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/restclient/RestClientIntegrationTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/integration/restclient/RestClientIntegrationTest.java
@@ -17,8 +17,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
@@ -35,6 +33,7 @@ import org.jboss.eap.qe.microprofile.openapi.apps.routing.router.services.Distri
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientRelatedException;
 import org.jboss.shrinkwrap.api.Archive;
@@ -111,16 +110,20 @@ public class RestClientIntegrationTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    static class OpenApiExtensionSetup implements ServerSetupTask {
+    static class OpenApiExtensionSetup implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.enableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void setup() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.enableOpenApi(client);
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.disableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.disableOpenApi(client);
+            }
         }
     }
 

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/model/ProgrammingModelTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/model/ProgrammingModelTest.java
@@ -17,8 +17,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
@@ -27,6 +25,7 @@ import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.data.District
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.model.District;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.rest.DistrictsResource;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.services.InMemoryDistrictService;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -35,6 +34,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 
 /**
  * Test cases for MP OpenAPI programming model (migrated from TT QE TS)
@@ -72,16 +72,20 @@ public class ProgrammingModelTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    static class OpenApiExtensionSetup implements ServerSetupTask {
+    static class OpenApiExtensionSetup implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.enableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void setup() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.enableOpenApi(client);
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.disableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.disableOpenApi(client);
+            }
         }
     }
 

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v10/OpenApi10OnJaxRsAnnotationsTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v10/OpenApi10OnJaxRsAnnotationsTest.java
@@ -13,8 +13,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
@@ -23,6 +21,7 @@ import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.data.District
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.model.District;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.rest.DistrictsResource;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.services.InMemoryDistrictService;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -60,16 +59,20 @@ public class OpenApi10OnJaxRsAnnotationsTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    static class OpenApiExtensionSetup implements ServerSetupTask {
+    static class OpenApiExtensionSetup implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.enableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void setup() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.enableOpenApi(client);
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.disableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.disableOpenApi(client);
+            }
         }
     }
 

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v11/MicroProfileOpenApi11Test.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/v11/MicroProfileOpenApi11Test.java
@@ -17,8 +17,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.openapi.OpenApiServerConfiguration;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.ProviderApplication;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
@@ -27,6 +25,7 @@ import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.data.District
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.model.District;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.rest.DistrictsResource;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.services.InMemoryDistrictService;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -35,6 +34,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.yaml.snakeyaml.Yaml;
 
 /**
@@ -61,16 +61,20 @@ public class MicroProfileOpenApi11Test {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    static class OpenApiExtensionSetup implements ServerSetupTask {
+    static class OpenApiExtensionSetup implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.enableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void setup() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.enableOpenApi(client);
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
-            OpenApiServerConfiguration.disableOpenApi(ManagementClientProvider.onlineStandalone(managementClient));
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                OpenApiServerConfiguration.disableOpenApi(client);
+            }
         }
     }
 

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/creaper/ManagementClientProvider.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/creaper/ManagementClientProvider.java
@@ -53,6 +53,7 @@ public class ManagementClientProvider {
      *        {@link OnlineManagementClient} returned.
      * @return Initialized {@link OnlineManagementClient} instance, don't forget to close it
      */
+    @Deprecated
     public static OnlineManagementClient onlineStandalone(org.jboss.as.arquillian.container.ManagementClient managementClient) {
         return org.wildfly.extras.creaper.core.ManagementClient.onlineLazy(
                 OnlineOptions.standalone().wrap(managementClient.getControllerClient()));


### PR DESCRIPTION
Using new instance of OnlineManagementClient which is not wrapping the one provided by Arquillian.
This PR is deprecating 

* https://github.com/jboss-eap-qe/eap-microprofile-test-suite/blob/master/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/configuration/creaper/ManagementClientProvider.java#L56

following guidelines at #169.

Test job run: https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-testsuite/61/

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented