### PR TITLE
MP Metrics tests use MicroProfileServerSetupTask and Creaper client

### DIFF
--- a/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceProviderTest.java
+++ b/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceProviderTest.java
@@ -10,9 +10,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.tooling.server.ModuleUtil;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -65,11 +64,11 @@ public class CustomMetricCustomConfigSourceProviderTest extends CustomMetricDyna
      * Setup a microprofile-config-smallrye subsystem to obtain values from {@link CustomConfigSource} provided by
      * {@link CustomConfigSourceProvider}
      */
-    static class SetupTask implements ServerSetupTask {
+    static class SetupTask implements MicroProfileServerSetupTask {
         private static final String TEST_MODULE_NAME = "test.custom-config-source-provider";
 
         @Override
-        public void setup(ManagementClient managementClient, String s) throws Exception {
+        public void setup() throws Exception {
             try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
                 client.execute(String.format("/system-property=%s:add(value=%s)", CustomConfigSource.FILEPATH_PROPERTY,
                         SetupTask.class.getResource(PROPERTY_FILENAME).getPath()));
@@ -84,7 +83,7 @@ public class CustomMetricCustomConfigSourceProviderTest extends CustomMetricDyna
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String s) throws Exception {
+        public void tearDown() throws Exception {
             try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
                 client.execute(String.format("/system-property=%s:remove", CustomConfigSource.FILEPATH_PROPERTY));
                 client.execute("/subsystem=microprofile-config-smallrye/config-source-provider=cs-from-provider:remove");

--- a/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceTest.java
+++ b/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceTest.java
@@ -10,9 +10,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.tooling.server.ModuleUtil;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -63,11 +62,11 @@ public class CustomMetricCustomConfigSourceTest extends CustomMetricDynamicBaseT
      * Setup a microprofile-config-smallrye subsystem to obtain values from {@link CustomConfigSource} provided by
      * {@link CustomConfigSourceProvider}
      */
-    static class SetupTask implements ServerSetupTask {
+    static class SetupTask implements MicroProfileServerSetupTask {
         private static final String TEST_MODULE_NAME = "test.custom-config-source";
 
         @Override
-        public void setup(ManagementClient managementClient, String s) throws Exception {
+        public void setup() throws Exception {
             try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
                 client.execute(String.format("/system-property=%s:add(value=%s)", CustomConfigSource.FILEPATH_PROPERTY,
                         CustomMetricCustomConfigSourceProviderTest.SetupTask.class.getResource(PROPERTY_FILENAME).getPath()));
@@ -82,7 +81,7 @@ public class CustomMetricCustomConfigSourceTest extends CustomMetricDynamicBaseT
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String s) throws Exception {
+        public void tearDown() throws Exception {
             try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
                 client.execute("/subsystem=microprofile-config-smallrye/config-source=cs-from-class:remove");
                 ModuleUtil.remove(TEST_MODULE_NAME).executeOn(client);

--- a/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricModelFilePropsTest.java
+++ b/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricModelFilePropsTest.java
@@ -1,31 +1,21 @@
 package org.jboss.eap.qe.microprofile.metrics.integration.config;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.concurrent.TimeoutException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.client.helpers.ClientConstants;
-import org.jboss.as.controller.operations.common.Util;
-import org.jboss.dmr.ModelNode;
-import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
@@ -38,11 +28,6 @@ import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 @RunAsClient
 @ServerSetup(CustomMetricModelFilePropsTest.SetupTask.class)
 public class CustomMetricModelFilePropsTest extends CustomMetricBaseTest {
-
-    private static final PathAddress CONFIG_SOURCE_PROPS_ADDRESS = PathAddress.pathAddress()
-            .append(SUBSYSTEM, "microprofile-config-smallrye")
-            .append("config-source", "file-props");
-
     private byte[] bytes;
 
     private Path incrementFilePath = Paths.get(
@@ -68,7 +53,7 @@ public class CustomMetricModelFilePropsTest extends CustomMetricBaseTest {
         Files.write(incrementFilePath, bytes);
     }
 
-    void setConfigProperties(int increment) throws IOException, ConfigurationException, TimeoutException, InterruptedException {
+    void setConfigProperties(int increment) throws Exception {
         //      TODO Java 11 API way - Files.writeString(incrementFilePath, Integer.toString(increment));
         Files.write(incrementFilePath, Integer.toString(increment).getBytes(StandardCharsets.UTF_8));
         try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
@@ -80,28 +65,24 @@ public class CustomMetricModelFilePropsTest extends CustomMetricBaseTest {
      * Setup a microprofile-config-smallrye subsystem to obtain values from a directory defined in the subsystem.
      * The directory contains files (file name is mapped to MP Config property name) which contain config values.
      */
-    public static class SetupTask implements ServerSetupTask {
+    static class SetupTask implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String s) throws Exception {
-            ModelNode dir = new ModelNode();
-            dir.get("path").set(SetupTask.class.getResource("file-props").getPath());
-            ModelNode add = Util.createAddOperation(CONFIG_SOURCE_PROPS_ADDRESS);
-            add.get("dir").set(dir);
-            Assert.assertEquals(ClientConstants.SUCCESS, managementClient
-                    .getControllerClient()
-                    .execute(add)
-                    .get(ClientConstants.OUTCOME)
-                    .asString());
+        public void setup() throws Exception {
+            String dir = SetupTask.class.getResource("file-props").getFile();
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                client.execute(
+                        String.format("/subsystem=microprofile-config-smallrye/config-source=file-props:add(dir={path=%s})",
+                                dir))
+                        .assertSuccess();
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String s) throws Exception {
-            Assert.assertEquals(ClientConstants.SUCCESS, managementClient
-                    .getControllerClient()
-                    .execute(Util.createRemoveOperation(CONFIG_SOURCE_PROPS_ADDRESS))
-                    .get(ClientConstants.OUTCOME)
-                    .asString());
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                client.execute("/subsystem=microprofile-config-smallrye/config-source=file-props:remove").assertSuccess();
+            }
         }
     }
 }

--- a/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricModelPropsTest.java
+++ b/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricModelPropsTest.java
@@ -1,26 +1,14 @@
 package org.jboss.eap.qe.microprofile.metrics.integration.config;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-
-import java.io.IOException;
-import java.util.concurrent.TimeoutException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.client.helpers.ClientConstants;
-import org.jboss.as.controller.operations.common.Util;
-import org.jboss.dmr.ModelNode;
-import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
@@ -33,10 +21,6 @@ import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 @ServerSetup(CustomMetricModelPropsTest.SetupTask.class)
 public class CustomMetricModelPropsTest extends CustomMetricBaseTest {
 
-    private static final PathAddress CONFIG_SOURCE_PROPS_ADDRESS = PathAddress.pathAddress()
-            .append(SUBSYSTEM, "microprofile-config-smallrye")
-            .append("config-source", "props");
-
     @Deployment(testable = false)
     public static WebArchive createDeployment() {
         WebArchive webArchive = ShrinkWrap.create(WebArchive.class, CustomMetricModelPropsTest.class.getSimpleName() + ".war")
@@ -46,10 +30,11 @@ public class CustomMetricModelPropsTest extends CustomMetricBaseTest {
         return webArchive;
     }
 
-    void setConfigProperties(int increment) throws IOException, ConfigurationException, TimeoutException, InterruptedException {
+    void setConfigProperties(int increment) throws Exception {
         try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
-            ModelNode properties = new ModelNode().add(INCREMENT_CONFIG_PROPERTY, increment);
-            client.execute(Util.getWriteAttributeOperation(CONFIG_SOURCE_PROPS_ADDRESS, "properties", properties))
+            client.execute(String.format(
+                    "/subsystem=microprofile-config-smallrye/config-source=props:write-attribute(name=properties, value={%s=%s}",
+                    INCREMENT_CONFIG_PROPERTY, increment))
                     .assertSuccess();
             new Administration(client).reload();
         }
@@ -58,24 +43,20 @@ public class CustomMetricModelPropsTest extends CustomMetricBaseTest {
     /**
      * Setup a microprofile-config-smallrye subsystem to obtain values from properties defined in the subsystem.
      */
-    public static class SetupTask implements ServerSetupTask {
+    static class SetupTask implements MicroProfileServerSetupTask {
 
         @Override
-        public void setup(ManagementClient managementClient, String s) throws Exception {
-            Assert.assertEquals(ClientConstants.SUCCESS, managementClient
-                    .getControllerClient()
-                    .execute(Util.createAddOperation(CONFIG_SOURCE_PROPS_ADDRESS))
-                    .get(ClientConstants.OUTCOME)
-                    .asString());
+        public void setup() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                client.execute("/subsystem=microprofile-config-smallrye/config-source=props:add").assertSuccess();
+            }
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String s) throws Exception {
-            Assert.assertEquals(ClientConstants.SUCCESS, managementClient
-                    .getControllerClient()
-                    .execute(Util.createRemoveOperation(CONFIG_SOURCE_PROPS_ADDRESS))
-                    .get(ClientConstants.OUTCOME)
-                    .asString());
+        public void tearDown() throws Exception {
+            try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+                client.execute("/subsystem=microprofile-config-smallrye/config-source=props:remove").assertSuccess();
+            }
         }
     }
 }

--- a/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/ft/FTMetricTest.java
+++ b/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/ft/FTMetricTest.java
@@ -20,14 +20,13 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.eap.qe.microprofile.tooling.server.ModuleUtil;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -180,7 +179,7 @@ public class FTMetricTest {
      * Setup a microprofile-config-smallrye subsystem to obtain values from {@link FTCustomConfigSource}.
      * Add MP FT subsystem.
      */
-    static class SetupTask implements ServerSetupTask {
+    static class SetupTask implements MicroProfileServerSetupTask {
         private static final String TEST_MODULE_NAME = "test.ft-custom-config-source";
         private static final String PROPERTY_FILENAME = "ft-custom-metric.properties";
         static Path propertyFilePath = Paths.get(SetupTask.class.getResource(PROPERTY_FILENAME).getPath());
@@ -190,7 +189,7 @@ public class FTMetricTest {
                 "microprofile-fault-tolerance-smallrye");
 
         @Override
-        public void setup(ManagementClient managementClient, String s) throws Exception {
+        public void setup() throws Exception {
             try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
                 client.execute(String.format("/system-property=%s:add(value=%s)", FTCustomConfigSource.FILEPATH_PROPERTY,
                         SetupTask.class.getResource(PROPERTY_FILENAME).getPath()));
@@ -207,7 +206,7 @@ public class FTMetricTest {
         }
 
         @Override
-        public void tearDown(ManagementClient managementClient, String s) throws Exception {
+        public void tearDown() throws Exception {
             try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
                 client.execute("/subsystem=microprofile-config-smallrye/config-source=cs-from-class:remove");
                 ModuleUtil.remove(TEST_MODULE_NAME).executeOn(client);


### PR DESCRIPTION
Fixes https://github.com/jboss-eap-qe/eap-microprofile-test-suite/issues/169

```
[INFO] Results:
[INFO] 
[WARNING] Tests run: 35, Failures: 0, Errors: 0, Skipped: 2
```


Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [   Description of the tests scenarios is included (see #46)