### PR TITLE
MP health disable default procedures

### DIFF
--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/DefaultReadinessProcedureHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/DefaultReadinessProcedureHealthTest.java
@@ -1,0 +1,108 @@
+package org.jboss.eap.qe.microprofile.health;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.eap.qe.microprofile.health.tools.HealthUrlProvider;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+/**
+ * Tests case to assess the behavior when no readiness health check procedures are registered explicitly by any
+ * deployment, so default procedures would provide one.
+ * This is since Wildfly 19 beta 2, see: <br>
+ * - Default procedures in MicroProfile Health 2.2:
+ * https://download.eclipse.org/microprofile/microprofile-health-2.2/microprofile-health-spec.html#_disabling_default_vendor_procedures
+ * <br>
+ * - Wildfly issue: https://issues.redhat.com/browse/WFLY-12952 <br>
+ * - Wildfly PR: https://github.com/wildfly/wildfly/pull/12940
+ */
+@RunAsClient
+@RunWith(Arquillian.class)
+public class DefaultReadinessProcedureHealthTest {
+
+    public static final String ARCHIVE_NAME = DefaultReadinessProcedureHealthTest.class.getSimpleName() + ".war";
+
+    @Deployment(testable = false)
+    public static Archive<?> deployment() {
+        return ShrinkWrap.create(WebArchive.class, ARCHIVE_NAME)
+                .addClasses(LivenessHealthCheck.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    /**
+     * @tpTestDetails Calls the deprecated {@code health} endpoint to get response from all health check procedures
+     * @tpPassCrit Overall health check status is up and two checks are expected to be returned: one {@code liveness}
+     *             check - which is defined by the {@link LivenessHealthCheck} annotated class and has "UP" status and data -
+     *             and
+     *             one {@code readiness} check - which is provided by Wildfly because none was defined in the deployment and the
+     *             {@code mp.health.disable-default-procedures} being set to {@code false} by default. This last check must be
+     *             conventionally named after the deplyment name - i.e namely: {@code "ready-deployment." + deployment name}
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Test
+    public void testHealthEndpoint() throws ConfigurationException {
+        RestAssured.get(HealthUrlProvider.healthEndpoint()).then()
+                .contentType(ContentType.JSON)
+                .body("status", is("UP"),
+                        "checks", hasSize(2),
+                        "checks.status", hasItems("UP", "UP"),
+                        "checks.name", containsInAnyOrder(String.format("ready-deployment.%s", ARCHIVE_NAME), "live"),
+                        "checks.data", hasSize(2),
+                        "checks.data.key", contains("value"));
+    }
+
+    /**
+     * @tpTestDetails Calls the {@code live} endpoint to get response from all {@code liveness} procedures
+     * @tpPassCrit Overall health check status is up and one check is expected to be returned, i.e the {@code liveness}
+     *             check which is defined by the {@link LivenessHealthCheck} annotated class and has "UP" status and data.
+     *             So this is to assess that the value of {@code mp.health.disable-default-procedures} is not affecting
+     *             {@code liveness} probes at all.
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Test
+    public void testLivenessEndpoint() throws ConfigurationException {
+        RestAssured.get(HealthUrlProvider.liveEndpoint()).then()
+                .contentType(ContentType.JSON)
+                .body("status", is("UP"),
+                        "checks", hasSize(1),
+                        "checks.status", hasItems("UP"),
+                        "checks.name", contains("live"),
+                        "checks.data", hasSize(1),
+                        "checks.data[0].key", is("value"));
+    }
+
+    /**
+     * @tpTestDetails Calls the {@code ready} endpoint to get response from all {@code readiness} procedures
+     * @tpPassCrit Overall health check status is up and one check is expected to be returned, i.e the {@code readiness}
+     *             check which is provided by Wildfly because none was defined in the deployment and the
+     *             {@code mp.health.disable-default-procedures} being set to {@code false} by default. It must be
+     *             conventionally named after the deplyment name - i.e namely: {@code "ready-deployment." + deployment name}
+     * @tpSince EAP 7.4.0.CD19
+     */
+    @Test
+    public void testReadinessEndpoint() throws ConfigurationException {
+        RestAssured.get(HealthUrlProvider.readyEndpoint()).then()
+                .contentType(ContentType.JSON)
+                .body("status", is("UP"),
+                        "checks", hasSize(1),
+                        "checks.status", hasItems("UP"),
+                        "checks.name", contains(String.format("ready-deployment.%s", ARCHIVE_NAME)),
+                        "checks.data", contains(nullValue()));
+    }
+}

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/HealthDeprecatedTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/HealthDeprecatedTest.java
@@ -14,6 +14,7 @@ import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationE
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +29,8 @@ public class HealthDeprecatedTest {
     public static Archive<?> deployment() {
         return ShrinkWrap.create(WebArchive.class, HealthDeprecatedTest.class.getSimpleName() + ".war")
                 .addClasses(DeprecatedHealthCheck.class)
+                .addAsManifestResource(new StringAsset("mp.health.disable-default-procedures=true"),
+                        "microprofile-config.properties")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/HealthNullTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/HealthNullTest.java
@@ -13,6 +13,7 @@ import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationE
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,6 +28,8 @@ public class HealthNullTest {
     public static Archive<?> deployment() {
         return ShrinkWrap.create(WebArchive.class, HealthNullTest.class.getSimpleName() + ".war")
                 .addClasses(NullLivenessHealthCheck.class)
+                .addAsManifestResource(new StringAsset("mp.health.disable-default-procedures=true"),
+                        "microprofile-config.properties")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MultiDeploymentHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MultiDeploymentHealthTest.java
@@ -15,6 +15,7 @@ import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationE
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,6 +32,8 @@ public class MultiDeploymentHealthTest {
     public static Archive<?> deployment1() {
         return ShrinkWrap.create(WebArchive.class, MultiDeploymentHealthTest.class.getSimpleName() + "-1.war")
                 .addClasses(BothHealthCheck.class)
+                .addAsManifestResource(new StringAsset("mp.health.disable-default-procedures=true"),
+                        "microprofile-config.properties")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
@@ -38,6 +41,8 @@ public class MultiDeploymentHealthTest {
     public static Archive<?> deployment2() {
         return ShrinkWrap.create(WebArchive.class, MultiDeploymentHealthTest.class.getSimpleName() + "-2.war")
                 .addClasses(LivenessHealthCheck.class)
+                .addAsManifestResource(new StringAsset("mp.health.disable-default-procedures=true"),
+                        "microprofile-config.properties")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 


### PR DESCRIPTION
* Fixing "old" tests that were not providing a readiness check in order to set `mp.health.disable-default-procedures` to true so that default readiness checks are not created and assertions are working (after https://issues.redhat.com/browse/WFLY-12952 and https://github.com/wildfly/wildfly/pull/12940).

* Adding test coverage to assess basic behavior of default readiness probe result when mp.health.disable-default-procedures property is set to false (default), see https://download.eclipse.org/microprofile/microprofile-health-2.2/microprofile-health-spec.html#_disabling_default_vendor_procedures and https://github.com/wildfly/wildfly/pull/12940

- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- N/A - Link to the passing job is provided: Jenkins is super busy, tests pass locally
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)