### PR TITLE
[WFLY-13024] Remove/update hystrix dependant tests and configuration properties

### DIFF
--- a/microprofile-fault-tolerance/src/main/java/org/jboss/eap/qe/microprofile/fault/tolerance/deployments/v20/AsyncHelloService.java
+++ b/microprofile-fault-tolerance/src/main/java/org/jboss/eap/qe/microprofile/fault/tolerance/deployments/v20/AsyncHelloService.java
@@ -35,21 +35,6 @@ public class AsyncHelloService {
         });
     }
 
-    @Bulkhead(value = 15, waitingTaskQueue = 15)
-    @Timeout(value = 1000)
-    @Fallback(fallbackMethod = "processFallback")
-    public CompletionStage<MyConnection> bulkheadTimeout(boolean fail) throws InterruptedException {
-        if (fail) {
-            Thread.sleep(2000);
-        }
-        return CompletableFuture.completedFuture(new MyConnection() {
-            @Override
-            public String getData() {
-                return "Hello from @Bulkhead @Timeout method";
-            }
-        });
-    }
-
     @Bulkhead(value = 15, waitingTaskQueue = 5)
     @Timeout(value = 1, unit = ChronoUnit.SECONDS)
     @Fallback(fallbackMethod = "processFallback")
@@ -144,21 +129,6 @@ public class AsyncHelloService {
             @Override
             public String getData() {
                 return "Hello from @Retry @CircuitBreaker method";
-            }
-        });
-    }
-
-    @Retry(retryOn = IOException.class)
-    @CircuitBreaker(failOn = IOException.class, requestVolumeThreshold = 5, successThreshold = 3, delay = 2, delayUnit = ChronoUnit.SECONDS, failureRatio = 0.75)
-    @Fallback(fallbackMethod = "processFallback")
-    public CompletionStage<MyConnection> retryCircuitBreaker(int counter) throws IOException {
-        if (counter % 4 != 0) { // 3/4 requests trigger IOException
-            throw new IOException("Simulated IOException");
-        }
-        return CompletableFuture.completedFuture(new MyConnection() {
-            @Override
-            public String getData() {
-                return "Hello from @Retry @CircuitBreaker method" + counter;
             }
         });
     }

--- a/microprofile-fault-tolerance/src/main/java/org/jboss/eap/qe/microprofile/fault/tolerance/deployments/v20/AsyncHelloServlet.java
+++ b/microprofile-fault-tolerance/src/main/java/org/jboss/eap/qe/microprofile/fault/tolerance/deployments/v20/AsyncHelloServlet.java
@@ -30,9 +30,6 @@ public class AsyncHelloServlet extends HttpServlet {
                 case "timeout":
                     completionStage = asyncHello.timeout(fail);
                     break;
-                case "bulkhead-timeout":
-                    completionStage = asyncHello.bulkheadTimeout(fail);
-                    break;
                 case "bulkhead-timeout-retry":
                     completionStage = asyncHello.bulkheadTimeoutRetry(fail);
                     break;

--- a/microprofile-fault-tolerance/src/main/java/org/jboss/eap/qe/microprofile/fault/tolerance/deployments/v20/AsyncPartialHelloServlet.java
+++ b/microprofile-fault-tolerance/src/main/java/org/jboss/eap/qe/microprofile/fault/tolerance/deployments/v20/AsyncPartialHelloServlet.java
@@ -40,9 +40,6 @@ public class AsyncPartialHelloServlet extends HttpServlet {
                 case "bulkhead15q5-timeout-retry":
                     completionStage = asyncHello.bulkhead15q5TimeoutRetry(counter);
                     break;
-                case "retry-circuitbreaker":
-                    completionStage = asyncHello.retryCircuitBreaker(counter);
-                    break;
                 case "retry-circuitbreaker-timeout":
                     completionStage = asyncHello.retryCircuitBreakerTimeout(counter);
                     break;

--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/CpuLoadTest.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/CpuLoadTest.java
@@ -48,7 +48,7 @@ public class CpuLoadTest {
 
     @Deployment(testable = false)
     public static Archive<?> createFirstWarDeployment() {
-        String mpConfig = "hystrix.command.default.execution.timeout.enabled=true";
+        String mpConfig = "Timeout/enabled=true";
         return ShrinkWrap.create(WebArchive.class, CpuLoadTest.class.getSimpleName() + ".war")
                 .addPackage(LoadService.class.getPackage())
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")

--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/MultipleFaultToleranceModuleEarTest.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/MultipleFaultToleranceModuleEarTest.java
@@ -4,7 +4,6 @@ import static io.restassured.RestAssured.get;
 import static org.hamcrest.Matchers.containsString;
 
 import java.net.URL;
-import java.util.regex.Pattern;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
@@ -19,9 +18,6 @@ import org.jboss.eap.qe.microprofile.fault.tolerance.util.MicroProfileFaultToler
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
-import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
-import org.jboss.eap.qe.microprofile.tooling.server.log.LogChecker;
-import org.jboss.eap.qe.microprofile.tooling.server.log.ModelNodeLogChecker;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -29,15 +25,14 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 
 /**
  * Tests deploy/undeploy of MP FT applications in EAR archive
+ * Note that this is test for multiple deployments which is currently unsupported feature in Wildfly/EAP.
  */
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -80,7 +75,7 @@ public class MultipleFaultToleranceModuleEarTest {
     }
 
     public static WebArchive createModule(String moduleName, boolean faultToleranceTimeoutEnabled) {
-        String mpConfig = "hystrix.command.default.execution.timeout.enabled=" + faultToleranceTimeoutEnabled;
+        String mpConfig = "Timeout/enabled=" + faultToleranceTimeoutEnabled;
         return ShrinkWrap.create(WebArchive.class, moduleName + ".war")
                 .addClasses(HelloService.class, HelloServlet.class, HelloFallback.class, MyContext.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
@@ -90,26 +85,6 @@ public class MultipleFaultToleranceModuleEarTest {
     @BeforeClass
     public static void setup() throws Exception {
         MicroProfileFaultToleranceServerConfiguration.enableFaultTolerance();
-    }
-
-    /**
-     * @tpTestDetails Deploy EAR with two MP FT modules. Both of them are the same (same classes/methods)
-     * @tpPassCrit Verify that warning will be logged with information that Hystrix was already initialized by first
-     *             application.
-     * @tpSince EAP 7.4.0.CD19
-     */
-    @Test
-    public void testDeployTwoModuleEarLogsWarning(@ArquillianResource @OperateOnDeployment(DEPLOYMENT_EAR) URL baseUrl)
-            throws Exception {
-        get(baseUrl + "/" + FIRST_MODULE_NAME + "?operation=retry&context=foobar&fail=true").then()
-                .assertThat()
-                .body(containsString("Fallback Hello, context = "));
-
-        try (final OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
-            final LogChecker logChecker = new ModelNodeLogChecker(client, 20, true);
-            Assert.assertTrue("Log does not contain warning that Hystrix was already initialized by first module",
-                    logChecker.logMatches(Pattern.compile(".*WFLYMPFTEXT0002.*")));
-        }
     }
 
     /**

--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/MultipleJarDeploymentTest.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/MultipleJarDeploymentTest.java
@@ -2,37 +2,31 @@ package org.jboss.eap.qe.microprofile.fault.tolerance;
 
 import static org.hamcrest.CoreMatchers.containsString;
 
-import java.util.regex.Pattern;
-
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.faulttolerance.FallbackHandler;
 import org.hamcrest.MatcherAssert;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.fault.tolerance.deployments.v10.HelloFallback;
 import org.jboss.eap.qe.microprofile.fault.tolerance.deployments.v10.HelloService;
 import org.jboss.eap.qe.microprofile.fault.tolerance.deployments.v10.MyContext;
 import org.jboss.eap.qe.microprofile.fault.tolerance.util.FaultToleranceServerSetup;
-import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.log.LogChecker;
-import org.jboss.eap.qe.microprofile.tooling.server.log.ModelNodeLogChecker;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 
 /**
  * Tests multiple deploy/undeploy of MP FT deployments (just JAR archives). This in in-container test which injects
  * MP FT service and invokes operations on it.
+ * Note that this is test for multiple deployments which is currently unsupported feature in Wildfly/EAP.
  */
 @RunWith(Arquillian.class)
 @ServerSetup(FaultToleranceServerSetup.class) // Enables/Disables fault tolerance extension/subsystem for Arquillian in-container tests
@@ -46,7 +40,7 @@ public class MultipleJarDeploymentTest {
 
     @Deployment(name = FIRST_DEPLOYMENT_JAR, order = 1, testable = false)
     public static Archive<?> createFirstJarDeployment() {
-        String mpConfig = "hystrix.command.default.execution.timeout.enabled=true";
+        String mpConfig = "Timeout/enabled=false";
 
         return ShrinkWrap.create(JavaArchive.class, FIRST_DEPLOYMENT_JAR + ".jar")
                 .addClasses(HelloService.class, MyContext.class, HelloFallback.class, FallbackHandler.class)
@@ -56,7 +50,7 @@ public class MultipleJarDeploymentTest {
 
     @Deployment(name = SECOND_DEPLOYMENT_JAR, order = 2)
     public static Archive<?> createSecondJarDeployment() {
-        String mpConfig = "hystrix.command.default.execution.timeout.enabled=false";
+        String mpConfig = "Timeout/enabled=true";
 
         return ShrinkWrap.create(JavaArchive.class, SECOND_DEPLOYMENT_JAR + ".jar")
                 .addClasses(HelloService.class, MyContext.class, HelloFallback.class, FallbackHandler.class)
@@ -66,29 +60,8 @@ public class MultipleJarDeploymentTest {
     }
 
     /**
-     * @tpTestDetails Deploy first and then second MP FT application. Both of them are the same (same classes/methods)
-     * @tpPassCrit Verify that second deployment causes that there is logged warning: "WFLYMPFTEXT0002: Hystrix was already
-     *             configured!
-     *             ..." and there is no ERROR message.
-     * @tpSince EAP 7.4.0.CD19
-     */
-    @Test
-    @RunAsClient
-    public void testDeploySecondJarLogsHystrixNoConfigChangeWarning() throws Exception {
-        try (final OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
-            final LogChecker logChecker = new ModelNodeLogChecker(client, 10, true);
-
-            Assert.assertTrue(
-                    "Log does not contain WARNING Log: WFLYMPFTEXT0002: Hystrix was already configured! Skipping configuration from deployment - but it should.",
-                    logChecker.logMatches(Pattern.compile(".*WFLYMPFTEXT0002.*")));
-            Assert.assertFalse("Log must not contain any ERROR logs but there are. See server log." + logChecker.toString(),
-                    logChecker.logMatches(Pattern.compile(".*ERROR.*")));
-        }
-    }
-
-    /**
      * @tpTestDetails Deploy first and then second MP FT application. Verify they're working.
-     * @tpPassCrit Verify that second deployment does NOT change MP FT/Hystrix configuration by disabling @Timeout
+     * @tpPassCrit Verify that second deployment uses its own MP FT configuration (with enabled @Timeout)
      * @tpSince EAP 7.4.0.CD19
      */
     @Test

--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/v10/MicroProfileFaultTolerance10Test.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/v10/MicroProfileFaultTolerance10Test.java
@@ -33,7 +33,6 @@ import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.Manage
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -52,15 +51,9 @@ public class MicroProfileFaultTolerance10Test {
 
     @Deployment(testable = false)
     public static Archive<?> deployment() {
-        String mpConfig = "hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=5000\n" +
-                "hystrix.command.default.execution.isolation.semaphore.maxConcurrentRequests=20\n" +
-                "hystrix.threadpool.default.maximumSize=40\n" +
-                "hystrix.threadpool.default.allowMaximumSizeToDivergeFromCoreSize=true\n";
-
         return ShrinkWrap.create(WebArchive.class, MicroProfileFaultTolerance10Test.class.getSimpleName() + ".war")
                 .addPackages(true, HelloService.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addAsManifestResource(new StringAsset(mpConfig), "microprofile-config.properties");
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @BeforeClass
@@ -252,7 +245,6 @@ public class MicroProfileFaultTolerance10Test {
     }
 
     private static void testCircuitBreakerFailure(String url, String expectedFallbackResponse, String expectedOkResponse) {
-        // hystrix.command.default.circuitBreaker.requestVolumeThreshold
         int initialRequestsCount = 20;
 
         for (int i = 0; i < initialRequestsCount; i++) {
@@ -260,7 +252,6 @@ public class MicroProfileFaultTolerance10Test {
                     .body(containsString(expectedFallbackResponse));
         }
 
-        // initialRequestsCount * hystrix.command.default.circuitBreaker.errorThresholdPercentage
         int failuresCount = 10;
 
         for (int i = 0; i < failuresCount; i++) {

--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/v20/FaultTolerance20AsyncPartialTest.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/v20/FaultTolerance20AsyncPartialTest.java
@@ -163,35 +163,6 @@ public class FaultTolerance20AsyncPartialTest {
     }
 
     /**
-     * @tpTestDetails Test sends 16 parallel requests. There are annotations on service:
-     *                Retry(retryOn = IOException.class), CircuitBreaker(failOn = IOException.class,
-     *                requestVolumeThreshold = 5, successThreshold = 3, delay = 2, delayUnit = ChronoUnit.SECONDS, failureRatio
-     *                = 0.75)
-     *                4 requests pass, 12 invoke IOException.
-     * @tpPassCrit After that the circuit is open, after at most 3 seconds it is closed.
-     * @tpSince EAP 7.4.0.CD19
-     */
-    @Test
-    @RunAsClient
-    public void retryCircuitBreaker() throws InterruptedException {
-        Map<String, Range<Integer>> expectedResponses = new HashMap<>();
-        expectedResponses.put("Hello from @Retry @CircuitBreaker method", Range.closed(0, 4));
-        expectedResponses.put("Fallback Hello", Range.closed(12, 16));
-        testPartial(16, baseApplicationUrl + "partial?operation=retry-circuitbreaker&counter=", expectedResponses);
-
-        // ensure circuit is opened (note number 88 does request correct behavior!)
-        String response2 = RestAssured.when().get(baseApplicationUrl + "partial?operation=retry-circuitbreaker&counter=88")
-                .asString();
-        assertThat(response2, is("Fallback Hello88"));
-        // ensure circuit is closed
-        await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
-            String response = RestAssured.when()
-                    .get(baseApplicationUrl + "partial?operation=retry-circuitbreaker&counter=88").asString();
-            assertThat(response, is("Hello from @Retry @CircuitBreaker method88"));
-        });
-    }
-
-    /**
      * @tpTestDetails Test sends 20 parallel requests. There are annotations on service:
      *                Retry(maxRetries = 2), CircuitBreaker(failOn = TimeoutException.class), Timeout
      *                5 requests pass, 10 invoke TimeoutException, 5 requests time-out.

--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/v20/FaultTolerance20AsyncPartialTest.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/v20/FaultTolerance20AsyncPartialTest.java
@@ -29,7 +29,6 @@ import org.jboss.eap.qe.microprofile.fault.tolerance.util.MicroProfileFaultToler
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -48,15 +47,10 @@ public class FaultTolerance20AsyncPartialTest {
 
     @Deployment
     public static Archive<?> deployment() {
-        String mpConfig = "hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=6000\n" +
-                "hystrix.command.default.execution.isolation.semaphore.maxConcurrentRequests=20\n" +
-                "hystrix.threadpool.default.maximumSize=40\n" +
-                "hystrix.threadpool.default.allowMaximumSizeToDivergeFromCoreSize=true\n";
         return ShrinkWrap.create(WebArchive.class, FaultTolerance20AsyncPartialTest.class.getSimpleName() + ".war")
                 .addPackages(true, AsyncHelloService.class.getPackage())
                 .addClasses(TimeoutException.class, FaultToleranceException.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addAsManifestResource(new StringAsset(mpConfig), "microprofile-config.properties");
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @BeforeClass

--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/v20/FaultTolerance20AsyncTest.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/v20/FaultTolerance20AsyncTest.java
@@ -31,7 +31,6 @@ import org.jboss.eap.qe.microprofile.fault.tolerance.util.MicroProfileFaultToler
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -46,15 +45,10 @@ public class FaultTolerance20AsyncTest {
 
     @Deployment
     public static Archive<?> deployment() {
-        String mpConfig = "hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=6000\n" +
-                "hystrix.command.default.execution.isolation.semaphore.maxConcurrentRequests=20\n" +
-                "hystrix.threadpool.default.maximumSize=40\n" +
-                "hystrix.threadpool.default.allowMaximumSizeToDivergeFromCoreSize=true\n";
         return ShrinkWrap.create(WebArchive.class, FaultTolerance20AsyncTest.class.getSimpleName() + ".war")
                 .addClasses(TimeoutException.class, FaultToleranceException.class)
                 .addPackages(true, AsyncHelloService.class.getPackage())
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addAsManifestResource(new StringAsset(mpConfig), "microprofile-config.properties");
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @BeforeClass
@@ -89,7 +83,7 @@ public class FaultTolerance20AsyncTest {
     }
 
     /**
-     * @tpTestDetails Deploy MP FT application with 1 second @Timeout, @BulkHead (hystrix.threadpool.default.maximumSize=40)
+     * @tpTestDetails Deploy MP FT application with 1 second @Timeout, @BulkHead
      *                and @Asynchronous annotation on service method and call 40 times. Call takes longer than defined timeout.
      * @tpPassCrit All 40 invocation ends in Fallback method as timeout was exceeded
      * @tpSince EAP 7.4.0.CD19
@@ -100,14 +94,14 @@ public class FaultTolerance20AsyncTest {
         Map<String, Integer> expectedResponses = new HashMap<>();
         expectedResponses.put("Hello from @Bulkhead @Timeout method", 0);
         expectedResponses.put("Fallback Hello", 40);
-        // timeout takes effect, there will be 40 fallbacks (hystrix.threadpool.default.maximumSize: 40)
+        // timeout takes effect, there will be 40 fallbacks
         // 41 invocations would already trigger fallback rejection
         // no matter @Bulkhead has e.g. value = 15 and waitingTaskQueue = 5
         testBulkhead(40, baseApplicationUrl + "async?operation=bulkhead-timeout&fail=true", expectedResponses);
     }
 
     /**
-     * @tpTestDetails Deploy MP FT application with 1 second @Timeout, @BulkHead (hystrix.threadpool.default.maximumSize=40)
+     * @tpTestDetails Deploy MP FT application with 1 second @Timeout, @BulkHead
      *                and @Asynchronous and @Retry annotations on service method and call it. Call takes less than defined
      *                timeout.
      * @tpPassCrit Invocation succeeds as fail was present
@@ -122,7 +116,6 @@ public class FaultTolerance20AsyncTest {
 
     /**
      * @tpTestDetails Deploy MP FT application with 1 second @Timeout, @Retry, @BulkHead
-     *                (hystrix.threadpool.default.maximumSize=40)
      *                and @Asynchronous annotation on service method and call 40 times. Call takes longer than defined timeout.
      * @tpPassCrit All 40 invocation ends in Fallback method as timeout and retires were exceeded
      * @tpSince EAP 7.4.0.CD19

--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/v20/FaultTolerance20AsyncTest.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/v20/FaultTolerance20AsyncTest.java
@@ -84,24 +84,6 @@ public class FaultTolerance20AsyncTest {
 
     /**
      * @tpTestDetails Deploy MP FT application with 1 second @Timeout, @BulkHead
-     *                and @Asynchronous annotation on service method and call 40 times. Call takes longer than defined timeout.
-     * @tpPassCrit All 40 invocation ends in Fallback method as timeout was exceeded
-     * @tpSince EAP 7.4.0.CD19
-     */
-    @Test
-    @RunAsClient
-    public void bulkheadTimeoutFailure() throws InterruptedException {
-        Map<String, Integer> expectedResponses = new HashMap<>();
-        expectedResponses.put("Hello from @Bulkhead @Timeout method", 0);
-        expectedResponses.put("Fallback Hello", 40);
-        // timeout takes effect, there will be 40 fallbacks
-        // 41 invocations would already trigger fallback rejection
-        // no matter @Bulkhead has e.g. value = 15 and waitingTaskQueue = 5
-        testBulkhead(40, baseApplicationUrl + "async?operation=bulkhead-timeout&fail=true", expectedResponses);
-    }
-
-    /**
-     * @tpTestDetails Deploy MP FT application with 1 second @Timeout, @BulkHead
      *                and @Asynchronous and @Retry annotations on service method and call it. Call takes less than defined
      *                timeout.
      * @tpPassCrit Invocation succeeds as fail was present

--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/v20/PriorityOrderTest.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/v20/PriorityOrderTest.java
@@ -41,11 +41,7 @@ public class PriorityOrderTest {
 
     @Deployment
     public static Archive<?> deployment() {
-        String mpConfig = "hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=6000\n" +
-                "hystrix.command.default.execution.isolation.semaphore.maxConcurrentRequests=20\n" +
-                "hystrix.threadpool.default.maximumSize=40\n" +
-                "hystrix.threadpool.default.allowMaximumSizeToDivergeFromCoreSize=true\n" +
-                "mp.fault.tolerance.interceptor.priority=5000";
+        String mpConfig = "mp.fault.tolerance.interceptor.priority=5000";
         return ShrinkWrap.create(WebArchive.class, PriorityOrderTest.class.getSimpleName() + ".war")
                 .addPackages(true, AsyncHelloService.class.getPackage())
                 .addClasses(TimeoutException.class, FaultToleranceException.class)

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <version.javax.servlet.javax.servlet-api>3.0.1</version.javax.servlet.javax.servlet-api>
         <version.junit>4.12</version.junit>
         <version.org.apache.maven.plugins.maven-release-plugin>3.0.0-M1</version.org.apache.maven.plugins.maven-release-plugin>
-        <version.org.eclipse.microprofile>3.2</version.org.eclipse.microprofile>
+        <version.org.eclipse.microprofile>3.3</version.org.eclipse.microprofile>
         <version.org.jboss.arquillian>1.5.0.Final</version.org.jboss.arquillian>
         <version.org.jboss.wildfly.dist>19.0.0.Beta2</version.org.jboss.wildfly.dist>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>


### PR DESCRIPTION
This PR removes/updates hystrix dependent tests and configuration properties which are no longer needed because hystrix is being replaced by new implementation with upgrade from MP FT 2.0 do 2.1.

Do not merge this until https://issues.redhat.com/browse/WFLY-13024 is finished (assuming it will indeed remove hystrix) and MP is updated to 3.3.


Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)