### PR TITLE
Fixing ListenerSecurityConfigurationTest (open-api) to run with standalone-microprofile.xml (no remoting)

### DIFF
--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/security/ListenerSecurityConfigurationTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/security/ListenerSecurityConfigurationTest.java
@@ -134,7 +134,7 @@ public class ListenerSecurityConfigurationTest {
 
         result = listenersConfigurationOnlineManagementClient.execute(
                 "/subsystem=elytron/key-store=httpsGenKS:generate-key-pair(" +
-                        "alias=localhost,algorithm=RSA,key-size=1024,validity=365," +
+                        "alias=localhost,algorithm=RSA,key-size=2048,validity=365," +
                         "credential-reference={clear-text=secret},distinguished-name=\"CN=localhost\")");
         result.assertSuccess();
 
@@ -202,9 +202,11 @@ public class ListenerSecurityConfigurationTest {
                 "/subsystem=undertow/server=default-server/http-listener=default:remove");
         result.assertSuccess();
 
-        result = listenersConfigurationOnlineManagementClient.execute(
-                "/subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=connector-ref, value=https)");
-        result.assertSuccess();
+        if (isHttpRemotingConnectorSet()) {
+            result = listenersConfigurationOnlineManagementClient.execute(
+                    "/subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=connector-ref, value=https)");
+            result.assertSuccess();
+        }
 
         new Administration(listenersConfigurationOnlineManagementClient).reload();
     }
@@ -215,11 +217,21 @@ public class ListenerSecurityConfigurationTest {
                         "socket-binding=http,redirect-socket=https,enable-http2=true)");
         result.assertSuccess();
 
-        result = listenersConfigurationOnlineManagementClient.execute(
-                "/subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=connector-ref, value=default)");
-        result.assertSuccess();
+        if (isHttpRemotingConnectorSet()) {
+            result = listenersConfigurationOnlineManagementClient.execute(
+                    "/subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=connector-ref, value=default)");
+            result.assertSuccess();
+        }
 
         new Administration(listenersConfigurationOnlineManagementClient).reload();
+    }
+
+    private static boolean isHttpRemotingConnectorSet()
+            throws InterruptedException, TimeoutException, IOException, CliException {
+
+        ModelNodeResult result = listenersConfigurationOnlineManagementClient.execute(
+                "/subsystem=remoting/http-connector=http-remoting-connector:read-resource()");
+        return result.isSuccess();
     }
 
     /**


### PR DESCRIPTION
There will be new standard config fles in WildFly/EAP, see [WFLY-13099](https://issues.redhat.com/browse/WFLY-13099). This PR fixes `ListenerSecurityConfigurationTest` to run without `remoting` subsystem that is not present in the new configs. Additionaly, it increases key-size of the generated key pair to conform to the Java security requirements.


Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)