### PR TITLE
Enable MP-JWT subsystem when not enabled

### DIFF
--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/EnableJwtSubsystemRule.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/EnableJwtSubsystemRule.java
@@ -1,0 +1,62 @@
+package org.jboss.eap.qe.microprofile.jwt;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
+import org.junit.rules.ExternalResource;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.OperationException;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
+
+/**
+ * A JUnit rule to enable/disable MP-JWT subsystem
+ */
+public class EnableJwtSubsystemRule extends ExternalResource {
+
+    private static final Address MP_JWT_EXTENSION_ADDRESS = Address.extension("org.wildfly.extension.microprofile.jwt");
+    private static final Address MP_JWT_ADDRESS = Address.subsystem("microprofile-jwt-smallrye");
+
+    private boolean wasExtensionAdded;
+    private boolean wasSubsystemAdded;
+
+    @Override
+    protected void before() throws IOException, OperationException, TimeoutException, InterruptedException,
+            ConfigurationException {
+        try (final OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+            final Operations ops = new Operations(client);
+            /*
+             * if (!ops.exists(MP_JWT_EXTENSION_ADDRESS)) {
+             * ops.add(MP_JWT_EXTENSION_ADDRESS).assertSuccess();
+             * wasExtensionAdded = true;
+             * }
+             */
+            if (!ops.exists(MP_JWT_ADDRESS)) {
+                ops.add(MP_JWT_ADDRESS).assertSuccess();
+                wasSubsystemAdded = true;
+            }
+            new Administration(client).reload();
+        }
+    }
+
+    @Override
+    protected void after() {
+        try (final OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+            final Operations ops = new Operations(client);
+            if (wasExtensionAdded) {
+                ops.remove(MP_JWT_EXTENSION_ADDRESS).assertSuccess();
+            }
+            if (wasSubsystemAdded) {
+                ops.remove(MP_JWT_ADDRESS).assertSuccess();
+            }
+            if (wasExtensionAdded || wasSubsystemAdded) {
+                new Administration(client).reload();
+            }
+        } catch (IOException | ConfigurationException | InterruptedException | TimeoutException e) {
+            throw new IllegalStateException("Unexpected exception when removing MP-JWT subsystem", e);
+        }
+    }
+}

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/EnableJwtSubsystemSetupTask.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/EnableJwtSubsystemSetupTask.java
@@ -21,8 +21,8 @@ public class EnableJwtSubsystemSetupTask implements MicroProfileServerSetupTask 
             .extension("org.wildfly.extension.microprofile.jwt-smallrye");
     private static final Address MP_JWT_ADDRESS = Address.subsystem("microprofile-jwt-smallrye");
 
-    private boolean wasExtensionAdded;
-    private boolean wasSubsystemAdded;
+    private boolean wasExtensionAdded = false;
+    private boolean wasSubsystemAdded = false;
 
     @Override
     public void setup() throws IOException, OperationException, TimeoutException, InterruptedException,
@@ -37,7 +37,9 @@ public class EnableJwtSubsystemSetupTask implements MicroProfileServerSetupTask 
                 ops.add(MP_JWT_ADDRESS).assertSuccess();
                 wasSubsystemAdded = true;
             }
-            new Administration(client).reload();
+            if (wasExtensionAdded || wasSubsystemAdded) {
+                new Administration(client).reload();
+            }
         }
     }
 

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/EnableJwtSubsystemSetupTask.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/EnableJwtSubsystemSetupTask.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
-import org.junit.rules.ExternalResource;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.operations.Address;
 import org.wildfly.extras.creaper.core.online.operations.OperationException;
@@ -13,9 +13,9 @@ import org.wildfly.extras.creaper.core.online.operations.Operations;
 import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 
 /**
- * A JUnit rule to enable/disable MP-JWT subsystem
+ * A way enable/disable MP-JWT subsystem when not enabled
  */
-public class EnableJwtSubsystemRule extends ExternalResource {
+public class EnableJwtSubsystemSetupTask implements MicroProfileServerSetupTask {
 
     private static final Address MP_JWT_EXTENSION_ADDRESS = Address.extension("org.wildfly.extension.microprofile.jwt");
     private static final Address MP_JWT_ADDRESS = Address.subsystem("microprofile-jwt-smallrye");
@@ -24,7 +24,7 @@ public class EnableJwtSubsystemRule extends ExternalResource {
     private boolean wasSubsystemAdded;
 
     @Override
-    protected void before() throws IOException, OperationException, TimeoutException, InterruptedException,
+    public void setup() throws IOException, OperationException, TimeoutException, InterruptedException,
             ConfigurationException {
         try (final OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
             final Operations ops = new Operations(client);
@@ -43,7 +43,7 @@ public class EnableJwtSubsystemRule extends ExternalResource {
     }
 
     @Override
-    protected void after() {
+    public void tearDown() {
         try (final OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
             final Operations ops = new Operations(client);
             if (wasExtensionAdded) {
@@ -59,4 +59,5 @@ public class EnableJwtSubsystemRule extends ExternalResource {
             throw new IllegalStateException("Unexpected exception when removing MP-JWT subsystem", e);
         }
     }
+
 }

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/EnableJwtSubsystemSetupTask.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/EnableJwtSubsystemSetupTask.java
@@ -17,7 +17,8 @@ import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
  */
 public class EnableJwtSubsystemSetupTask implements MicroProfileServerSetupTask {
 
-    private static final Address MP_JWT_EXTENSION_ADDRESS = Address.extension("org.wildfly.extension.microprofile.jwt-smallrye");
+    private static final Address MP_JWT_EXTENSION_ADDRESS = Address
+            .extension("org.wildfly.extension.microprofile.jwt-smallrye");
     private static final Address MP_JWT_ADDRESS = Address.subsystem("microprofile-jwt-smallrye");
 
     private boolean wasExtensionAdded;

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/EnableJwtSubsystemSetupTask.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/EnableJwtSubsystemSetupTask.java
@@ -17,7 +17,7 @@ import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
  */
 public class EnableJwtSubsystemSetupTask implements MicroProfileServerSetupTask {
 
-    private static final Address MP_JWT_EXTENSION_ADDRESS = Address.extension("org.wildfly.extension.microprofile.jwt");
+    private static final Address MP_JWT_EXTENSION_ADDRESS = Address.extension("org.wildfly.extension.microprofile.jwt-smallrye");
     private static final Address MP_JWT_ADDRESS = Address.subsystem("microprofile-jwt-smallrye");
 
     private boolean wasExtensionAdded;
@@ -28,12 +28,10 @@ public class EnableJwtSubsystemSetupTask implements MicroProfileServerSetupTask 
             ConfigurationException {
         try (final OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
             final Operations ops = new Operations(client);
-            /*
-             * if (!ops.exists(MP_JWT_EXTENSION_ADDRESS)) {
-             * ops.add(MP_JWT_EXTENSION_ADDRESS).assertSuccess();
-             * wasExtensionAdded = true;
-             * }
-             */
+            if (!ops.exists(MP_JWT_EXTENSION_ADDRESS)) {
+                ops.add(MP_JWT_EXTENSION_ADDRESS).assertSuccess();
+                wasExtensionAdded = true;
+            }
             if (!ops.exists(MP_JWT_ADDRESS)) {
                 ops.add(MP_JWT_ADDRESS).assertSuccess();
                 wasSubsystemAdded = true;

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/ActivationPropertiesUnsetTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/ActivationPropertiesUnsetTest.java
@@ -4,13 +4,13 @@ import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.NonJwtJaxRsTestApplication;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -18,10 +18,8 @@ import org.junit.runner.RunWith;
  * Set of negative tests for subsystem activation.
  */
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class ActivationPropertiesUnsetTest {
-
-    @ClassRule
-    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     private static final String UNSET_AUTH_ACTIVATION_PROPERTY_DEPLOYMENT_NAME = "PROPERTIES_UNSET_DEPLOYMENT";
     private static final String NON_JWT_AUTH_ACTIVATION_PROPERTY_DEPLOYMENT_NAME = "OTHER_VALUE_DEPLOYMENT";

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/ActivationPropertiesUnsetTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/ActivationPropertiesUnsetTest.java
@@ -4,11 +4,13 @@ import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.NonJwtJaxRsTestApplication;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -17,6 +19,9 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class ActivationPropertiesUnsetTest {
+
+    @ClassRule
+    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     private static final String UNSET_AUTH_ACTIVATION_PROPERTY_DEPLOYMENT_NAME = "PROPERTIES_UNSET_DEPLOYMENT";
     private static final String NON_JWT_AUTH_ACTIVATION_PROPERTY_DEPLOYMENT_NAME = "OTHER_VALUE_DEPLOYMENT";

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/AnnotationActivationCompatibilityTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/AnnotationActivationCompatibilityTest.java
@@ -9,6 +9,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
@@ -19,6 +20,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -30,6 +32,9 @@ import io.restassured.RestAssured;
  */
 @RunWith(Arquillian.class)
 public class AnnotationActivationCompatibilityTest {
+
+    @ClassRule
+    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     private static RsaKeyTool keyTool;
 

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/AnnotationActivationCompatibilityTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/AnnotationActivationCompatibilityTest.java
@@ -9,7 +9,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
@@ -20,7 +21,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -31,10 +31,8 @@ import io.restassured.RestAssured;
  * subsystem when configured properly.
  */
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class AnnotationActivationCompatibilityTest {
-
-    @ClassRule
-    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     private static RsaKeyTool keyTool;
 

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/WebXmlActivationCompatibilityTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/WebXmlActivationCompatibilityTest.java
@@ -9,7 +9,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
@@ -20,7 +21,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -31,10 +31,8 @@ import io.restassured.RestAssured;
  * web.xml.
  */
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class WebXmlActivationCompatibilityTest {
-
-    @ClassRule
-    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     private static RsaKeyTool keyTool;
 

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/WebXmlActivationCompatibilityTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/activation/WebXmlActivationCompatibilityTest.java
@@ -9,6 +9,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
@@ -19,6 +20,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -30,6 +32,9 @@ import io.restassured.RestAssured;
  */
 @RunWith(Arquillian.class)
 public class WebXmlActivationCompatibilityTest {
+
+    @ClassRule
+    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     private static RsaKeyTool keyTool;
 

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/CorruptedJwtTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/CorruptedJwtTest.java
@@ -9,6 +9,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtDefaultClaimValues;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
@@ -18,6 +19,7 @@ import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.JaxRsTestApplication;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -28,6 +30,9 @@ import org.junit.runner.RunWith;
 @RunAsClient
 @RunWith(Arquillian.class)
 public class CorruptedJwtTest {
+
+    @ClassRule
+    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     @Deployment
     public static WebArchive createDeployment() {

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/CorruptedJwtTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/CorruptedJwtTest.java
@@ -9,7 +9,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtDefaultClaimValues;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
@@ -19,7 +20,6 @@ import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.JaxRsTestApplication;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -29,10 +29,8 @@ import org.junit.runner.RunWith;
  */
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class CorruptedJwtTest {
-
-    @ClassRule
-    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     @Deployment
     public static WebArchive createDeployment() {

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/ExpiredJwtTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/ExpiredJwtTest.java
@@ -13,7 +13,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtClaims;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtDefaultClaimValues;
@@ -24,16 +25,13 @@ import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.JaxRsTestApplication;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class ExpiredJwtTest {
-
-    @ClassRule
-    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     @Deployment
     public static WebArchive createDeployment() {

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/ExpiredJwtTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/ExpiredJwtTest.java
@@ -13,6 +13,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtClaims;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtDefaultClaimValues;
@@ -23,12 +24,16 @@ import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.JaxRsTestApplication;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunAsClient
 @RunWith(Arquillian.class)
 public class ExpiredJwtTest {
+
+    @ClassRule
+    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     @Deployment
     public static WebArchive createDeployment() {

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/JwtIssuerValueTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/JwtIssuerValueTest.java
@@ -9,6 +9,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
@@ -18,6 +19,7 @@ import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -28,6 +30,9 @@ import org.junit.runner.RunWith;
 @RunAsClient
 @RunWith(Arquillian.class)
 public class JwtIssuerValueTest {
+
+    @ClassRule
+    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     private static RsaKeyTool keyTool;
 

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/JwtIssuerValueTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/JwtIssuerValueTest.java
@@ -9,7 +9,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
@@ -19,7 +20,6 @@ import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -29,10 +29,8 @@ import org.junit.runner.RunWith;
  */
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class JwtIssuerValueTest {
-
-    @ClassRule
-    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     private static RsaKeyTool keyTool;
 

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/JwtMinimalClaimSetTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/JwtMinimalClaimSetTest.java
@@ -14,6 +14,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtClaims;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtDefaultClaimValues;
@@ -25,6 +26,7 @@ import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,6 +39,9 @@ import org.junit.runner.RunWith;
 @RunAsClient
 @RunWith(Arquillian.class)
 public class JwtMinimalClaimSetTest {
+
+    @ClassRule
+    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     private static final String SUBJECT = JwtDefaultClaimValues.SUBJECT;
     private static final String ISSUER = JwtDefaultClaimValues.ISSUER;

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/JwtMinimalClaimSetTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/compatibility/JwtMinimalClaimSetTest.java
@@ -14,7 +14,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtClaims;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtDefaultClaimValues;
@@ -26,7 +27,6 @@ import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,10 +38,8 @@ import org.junit.runner.RunWith;
 @Ignore("WFWIP-293")
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class JwtMinimalClaimSetTest {
-
-    @ClassRule
-    public static EnableJwtSubsystemRule enableJwtSubsystemRule = new EnableJwtSubsystemRule();
 
     private static final String SUBJECT = JwtDefaultClaimValues.SUBJECT;
     private static final String ISSUER = JwtDefaultClaimValues.ISSUER;

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
@@ -11,6 +11,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
 import org.jboss.eap.qe.microprofile.jwt.testapp.Endpoints;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.JaxRsTestApplication;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
@@ -70,7 +71,8 @@ public class KeycloakIntegrationHighLevelScenarioTest {
 
     @ClassRule
     public static TestRule ruleChain = RuleChain.outerRule(keycloakContainer)
-            .around(keycloakConfigurator);
+            .around(keycloakConfigurator)
+            .around(new EnableJwtSubsystemRule());
 
     @Deployment
     public static Archive<?> createDeployment() {

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
@@ -11,7 +11,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemRule;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.testapp.Endpoints;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.JaxRsTestApplication;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
@@ -32,6 +33,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class KeycloakIntegrationHighLevelScenarioTest {
 
     private static final String KEYCLOAK_REALM_NAME = "foobar";
@@ -71,8 +73,7 @@ public class KeycloakIntegrationHighLevelScenarioTest {
 
     @ClassRule
     public static TestRule ruleChain = RuleChain.outerRule(keycloakContainer)
-            .around(keycloakConfigurator)
-            .around(new EnableJwtSubsystemRule());
+            .around(keycloakConfigurator);
 
     @Deployment
     public static Archive<?> createDeployment() {

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/CorruptedKeyTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/CorruptedKeyTest.java
@@ -11,6 +11,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
@@ -36,6 +38,7 @@ import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
  */
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class CorruptedKeyTest {
 
     private static RsaKeyTool keyTool;

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/JoseHeaderAlgorithmTestCase.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/JoseHeaderAlgorithmTestCase.java
@@ -15,6 +15,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JoseHeader;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtClaims;
@@ -34,6 +36,7 @@ import io.restassured.RestAssured;
 
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class JoseHeaderAlgorithmTestCase {
 
     final static private String DEFAULT_DEPLOYMENT = "default-deployment";

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/KeySizeTestCase.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyproperties/KeySizeTestCase.java
@@ -11,6 +11,8 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
@@ -27,6 +29,7 @@ import io.restassured.RestAssured;
 
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class KeySizeTestCase {
 
     private static final String BITS_512_KEY_DEPLOYMENT = "512-bits-key-deployment";

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyselection/MultipleConfiguredPublicKeysSelectionLocationPropTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyselection/MultipleConfiguredPublicKeysSelectionLocationPropTest.java
@@ -14,6 +14,8 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
@@ -29,6 +31,7 @@ import org.junit.runner.RunWith;
  */
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class MultipleConfiguredPublicKeysSelectionLocationPropTest {
 
     private static final String DEPLOYMENT_WITH_BASE64_JWKS_LOCATION_PROPERTY = "deployment-base64-jwks-location";

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyselection/MultipleConfiguredPublicKeysSelectionTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyselection/MultipleConfiguredPublicKeysSelectionTest.java
@@ -14,6 +14,8 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
@@ -29,6 +31,7 @@ import org.junit.runner.RunWith;
  */
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class MultipleConfiguredPublicKeysSelectionTest {
 
     private static final String DEPLOYMENT_WITH_BASE64_JWKS = "deployment-base64-jwks";

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/publickeylocation/PublicKeyLocationPropertyTestCase.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/publickeylocation/PublicKeyLocationPropertyTestCase.java
@@ -19,6 +19,8 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
@@ -41,6 +43,7 @@ import io.undertow.util.Headers;
  */
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class PublicKeyLocationPropertyTestCase {
 
     private static final String DEPLOYMENT_KEY_FROM_HTTP = "deployment-obtaining-key-from-http";

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/publickeylocation/PublicKeyPropertyTestCase.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/publickeylocation/PublicKeyPropertyTestCase.java
@@ -11,6 +11,8 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
@@ -30,6 +32,7 @@ import io.restassured.RestAssured;
  * Set of tests verifying functionality of {@code mp.jwt.verify.publickey} property.
  */
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class PublicKeyPropertyTestCase {
 
     private static final String DEPLOYMENT_WITH_VALID_KEY = "valid-key-deployment";

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/rbac/RolesAllowedRbacTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/rbac/RolesAllowedRbacTest.java
@@ -12,6 +12,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.jwt.EnableJwtSubsystemSetupTask;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JsonWebToken;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.JwtHelper;
 import org.jboss.eap.qe.microprofile.jwt.auth.tool.RsaKeyTool;
@@ -33,6 +35,7 @@ import org.junit.runner.RunWith;
  */
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup(EnableJwtSubsystemSetupTask.class)
 public class RolesAllowedRbacTest {
 
     private static final String DENY_ALL = "deny-all";


### PR DESCRIPTION
This PR enables MP-JWT subsystem and adds an extension if not already added for each test.

FYI @mchoma 

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-testsuite/205/
- [x] Code is self-descriptive and/or documented
