### PR TITLE
Introducing EAP XP variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,61 @@ mvn clean verify -DskipTests -DskipITs -Djboss.dist=foo
 ./mvnw clean verify -DskipTests -DskipITs -Djboss.dist=foo
 ```
 
+## Target distributions and MicroProfile specs
+
+The default Maven behavior when running the above mentioned commands will be to 
+execute the test suite with its default settings - 
+i.e. being about MicroProfile, this resolves to the assumption that:
+
+* all of the MicroProfile specs modules test cases should be executed
+* if a server instance must be started up then the `standalone-microprofile.xml`
+ configuration should be used.
+
+What described above would fit in the scenarios of Wildfly (which includes all 
+of the MP specs since v. 19.0.0.Final) and EAP XP server distributions.
+
+When it comes to the standard EAP stream bits tests, then the test suite 
+behavior should be different. 
+Specifically, only the test cases belonging to the modules which relate to 
+those MicroProfile specs which constitute the so called `Observability layer`
+should be executed and the `standalone.xml` file should be used when starting 
+the server instance up.
+
+The MicroProfile `Observability layer` specs include:
+* MicroProfile Config
+* MicroProfile Metrics
+* Microprofile Health
+* MicroProfile OpenTracing (no tests in here for this one)
+
+In order to test the _just_ this reduced set of MicroProfile specs, then, an 
+additional property should be provided to the command lines described earlier, 
+namely `-Dmp.specs.scope=observability`.
+In such case Arquillian will use the standard `standalone.xml` configuration 
+file, too.
+Consequently, the command lines described earlier and adjusted would be 
+translated into the following variations:
+
+### Quick compilation
+```
+mvn clean verify -DskipTests -DskipITs -Djboss.dist=foo -Dmp.specs.scope=observability
+
+./mvnw clean verify -DskipTests -DskipITs -Djboss.dist=foo -Dmp.specs.scope=observability
+```
+
+### To run tests against a running server instance (let's suppose that who started it up knew which config file to use...):
+```
+mvn clean verify -pl microprofile-health -am -Dmp.specs.scope=observability
+
+./mvnw clean verify -pl microprofile-health -am -Dmp.specs.scope=observability
+```
+
+### To run tests against against a custom build:
+```
+mvn clean verify -Djboss.dist=/Users/rsvoboda/Downloads/wildfly-18.0.0.Final -Dmp.specs.scope=observability
+
+./mvnw clean verify -Djboss.dist=/Users/rsvoboda/Downloads/wildfly-18.0.0.Final -Dmp.specs.scope=observability
+```
+
 ## Zip distribution bundle
 Distribution bundle contains this testsuite, pre-loaded local maven repository and dump of Docker images used in tests.
 Creation of the `eap-microprofile-test-suite-dist.zip` bundle is managed via `./mp-ts.sh` script.

--- a/arquillian.xml
+++ b/arquillian.xml
@@ -7,7 +7,7 @@
             <configuration>
                 <property name="jbossHome">${basedir}/target/jboss-as</property>
                 <property name="javaVmArguments">-server -Xms64m -Xmx512m</property>
-                <property name="serverConfig">standalone.xml</property>
+                <property name="serverConfig">${jboss.configuration.file:standalone-microprofile.xml}</property>
                 <property name="managementAddress">127.0.0.1</property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">9990</property>
@@ -20,7 +20,7 @@
             <configuration>
                 <property name="jbossHome">${basedir}/target/jboss-as</property>
                 <property name="javaVmArguments">-server -Xms64m -Xmx256m -Djboss.socket.binding.port-offset=10000 -Djboss.server.base.dir=${container.base.dir.manual.mode}</property>
-                <property name="serverConfig">standalone.xml</property>
+                <property name="serverConfig">${jboss.configuration.file:standalone-microprofile.xml}</property>
                 <property name="managementAddress">127.0.0.1</property>
                 <property name="managementPort">19990</property>
                 <property name="waitForPorts">19990</property>

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -73,4 +73,31 @@
             <artifactId>postgresql</artifactId>
         </dependency>
     </dependencies>
+    
+    <profiles>
+        <profile>
+            <id>observability-layer-modules</id>
+            <activation>
+                <property>
+                    <name>mp.specs.scope</name>
+                    <value>observability</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- Disable the surefire tests -->
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -58,4 +58,30 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>observability-layer-modules</id>
+            <activation>
+                <property>
+                    <name>mp.specs.scope</name>
+                    <value>observability</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- Disable the surefire tests -->
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/microprofile-open-api/pom.xml
+++ b/microprofile-open-api/pom.xml
@@ -65,5 +65,32 @@
             <artifactId>gson</artifactId>
             <scope>test</scope>
         </dependency>
-    </dependencies>
+    </dependencies>    
+    
+    <profiles>
+        <profile>
+            <id>observability-layer-modules</id>
+            <activation>
+                <property>
+                    <name>mp.specs.scope</name>
+                    <value>observability</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- Disable the surefire tests -->
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,17 +14,17 @@
     <packaging>pom</packaging>
 
     <name>Test suite for MicroProfile on WF/EAP</name>
-
+    
     <modules>
         <module>tooling-cpu-load</module>
         <module>tooling-docker</module>
         <module>tooling-mp-jwt-auth-tool</module>
         <module>tooling-server-configuration</module>
         <module>microprofile-config</module>
-        <module>microprofile-fault-tolerance</module>
         <module>microprofile-health</module>
-        <module>microprofile-jwt</module>
         <module>microprofile-metrics</module>
+        <module>microprofile-fault-tolerance</module>
+        <module>microprofile-jwt</module>
         <module>microprofile-open-api</module>
     </modules>
 
@@ -194,25 +194,9 @@
         <connection>scm:git:git@github.com:jboss-eap-qe/eap-microprofile-test-suite.git</connection>
         <developerConnection>scm:git:git@github.com:jboss-eap-qe/eap-microprofile-test-suite.git</developerConnection>
     </scm>
-
+    
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
-                <configuration>
-                    <environmentVariables>
-                        <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
-                    </environmentVariables>
-                    <systemPropertyVariables>
-                        <jboss.home>${jboss.home}</jboss.home>
-                        <container.base.dir.manual.mode>${container.base.dir.manual.mode}</container.base.dir.manual.mode>
-                        <arquillian.xml>${maven.multiModuleProjectDirectory}/arquillian.xml</arquillian.xml>
-                        <module.path>${jboss.modules.path}</module.path>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
@@ -248,6 +232,82 @@
     </build>
 
     <profiles>
+        <!--
+            When the `mp.specs.scope` property is not set the TS will 
+            build/execute the full set of MicroProfile specs modules.
+            E.g.: when testing Wildfly, which has all of the MicroProfile specs 
+            in since v. 19.0.0.Final, or when testing against EAP XP.
+        -->            
+        <profile>
+            <id>enable-all-specs</id>
+            <activation>
+                <property>
+                    <name>!mp.specs.scope</name>
+                </property>              
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
+                        <configuration>
+                            <environmentVariables>
+                                <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                            </environmentVariables>
+                            <systemPropertyVariables>
+                                <jboss.home>${jboss.home}</jboss.home>                                
+                                <container.base.dir.manual.mode>${container.base.dir.manual.mode}</container.base.dir.manual.mode>
+                                <module.path>${jboss.modules.path}</module.path>
+                                <arquillian.xml>${maven.multiModuleProjectDirectory}/arquillian.xml</arquillian.xml>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--
+            When it comes to non-XP EAP testing then only the MicroProfile 
+            specs belonging to the so called "observability layer" should be 
+            tested, hence this profile should be activated by providing the 
+            `mp.specs.scope` property with the "observability-layer" value
+        -->
+        <profile>
+            <id>enable-observability-layer-specs</id>
+            <activation>
+                <property>
+                    <name>mp.specs.scope</name>
+                    <value>observability</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
+                        <configuration>
+                            <environmentVariables>
+                                <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                            </environmentVariables>
+                            <systemPropertyVariables>
+                                <jboss.home>${jboss.home}</jboss.home>                                
+                                <jboss.configuration.file>standalone.xml</jboss.configuration.file>
+                                <container.base.dir.manual.mode>${container.base.dir.manual.mode}</container.base.dir.manual.mode>
+                                <module.path>${jboss.modules.path}</module.path>
+                                <arquillian.xml>${maven.multiModuleProjectDirectory}/arquillian.xml</arquillian.xml>
+                            </systemPropertyVariables>
+                            <!-- MP Health integration tests with 
+                            MP Fault Tolerance must be excluded when testing 
+                            just the MP "observability layer" specs-->                            
+                            <excludes>
+                                <exclude>org.jboss.eap.qe.microprofile.health.integration.*Test</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>copy-wildfly</id>
             <activation>


### PR DESCRIPTION
This PR is to introduce configuration variants which allow for the TS to be built and executed by taking into account the target distribution version.
Main differences involve the fact that the TS will now execute the whole set of modules and will use `standalone-microprofile.xml` for server config by default. This behavior will fit in the scenario in which WIldfly and EAP XP stream bits are tested.
When testing against standard a EAP stream bits the TS will instead execute a reduced set of modules - i.e. those belonging to the MP observability layer and will use `standalone.xml`.
See the `README.md` file for more details.

The following Jenkins job runs were used to verify the changes:

* EAP XP:
https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-testsuite/jdk=oracle-java-11,label_exp=RHEL7/228

* EAP:
https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-testsuite/jdk=oracle-java-11,label_exp=RHEL7/229

* Wildfly:
https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-testsuite/jdk=oracle-java-11,label_exp=RHEL7/230

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- N/A Description of the tests scenarios is included (see #46)