### PR TITLE
Added test for scenario when realm name is unset

### DIFF
--- a/microprofile-jwt/src/main/java/org/jboss/eap/qe/microprofile/jwt/testapp/jaxrs/UnsetRealmNameJaxRsTestApplication.java
+++ b/microprofile-jwt/src/main/java/org/jboss/eap/qe/microprofile/jwt/testapp/jaxrs/UnsetRealmNameJaxRsTestApplication.java
@@ -1,0 +1,16 @@
+package org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+import org.eclipse.microprofile.auth.LoginConfig;
+
+/**
+ * Application which normally activates JWT subsystem using {@code org.eclipse.microprofile.auth.LoginConfig}
+ * annotation. This is however annotated by an annotation which is missing {@code realmName};
+ */
+@LoginConfig(authMethod = "MP-JWT")
+@ApplicationPath("/")
+public class UnsetRealmNameJaxRsTestApplication extends Application {
+
+}


### PR DESCRIPTION

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-testsuite/258/
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)