### PR TITLE
Don't rely on Operation.getExtensions() being modifiable

### DIFF
--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/model/OpenApiFilter.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/model/OpenApiFilter.java
@@ -1,5 +1,8 @@
 package org.jboss.eap.qe.microprofile.openapi.model;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.models.Operation;
 import org.jboss.eap.qe.microprofile.openapi.apps.routing.provider.RoutingServiceConstants;
@@ -19,8 +22,9 @@ public class OpenApiFilter implements OASFilter {
     public Operation filterOperation(Operation operation) {
         if ((operation.getExtensions() != null)
                 && operation.getExtensions().containsKey(RoutingServiceConstants.OPENAPI_OPERATION_EXTENSION_PROXY_FQDN_NAME)) {
-            operation.getExtensions().replace(RoutingServiceConstants.OPENAPI_OPERATION_EXTENSION_PROXY_FQDN_NAME,
-                    LOCAL_TEST_ROUTER_FQDN);
+            Map<String, Object> extensions = new HashMap<>(operation.getExtensions());
+            extensions.replace(RoutingServiceConstants.OPENAPI_OPERATION_EXTENSION_PROXY_FQDN_NAME, LOCAL_TEST_ROUTER_FQDN);
+            operation.setExtensions(extensions);
         }
         return operation;
     }


### PR DESCRIPTION
After https://github.com/wildfly/wildfly/pull/13409, the method call `operation.getExtensions()` returns immutable collection causing the processing of the code fail in runtime and thus the tests using it fail.

https://github.com/smallrye/smallrye-open-api/compare/1.2.3...2.0.0#diff-1933429eb3b6343719065d2a3c6ea622R25
 
I changed the code so that we don't rely on the returned collection being modifiable anymore.

Before: https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-testsuite-jbliznak/3/testReport/
After: https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-testsuite-jbliznak/4/testReport/