### PR TITLE
Provide env Jaeger variables for OpenTracing tests, use latest Jaeger…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,8 @@
                         <configuration>
                             <environmentVariables>
                                 <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                                <JAEGER_SAMPLER_PARAM>1.0</JAEGER_SAMPLER_PARAM>
+                                <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
                             </environmentVariables>
                             <systemPropertyVariables>
                                 <jboss.home>${jboss.home}</jboss.home>                                

--- a/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/DockerContainers.java
+++ b/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/DockerContainers.java
@@ -13,7 +13,7 @@ public class DockerContainers {
     } // avoid instantiation
 
     public static Docker jaeger() {
-        return new Docker.Builder("jaeger", "jaegertracing/all-in-one:1.15.1")
+        return new Docker.Builder("jaeger", "jaegertracing/all-in-one:1.18")
                 .setContainerReadyCondition(() -> {
                     try {
                         new Socket("127.0.0.1", 16686).close();


### PR DESCRIPTION
… version, update http.status_code

Fixes https://issues.redhat.com/browse/WFLY-13774
Changes:

1) Add Jaeger env variables to make Jaeger working again.
2) Use latest available Jaeger Docker version.

Successful job run - https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-testsuite/jdk=oracle-java-11,label_exp=RHEL7/348/

Please make sure your PR meets the following requirements:
- [X] Pull Request contains a description of the changes
- [X] Pull Request does not include fixes for multiple issues/topics
- [X] Code is formatted, imports ordered, code compiles and tests are passing
- [X] Link to the passing job is provided
- [X] Code is self-descriptive and/or documented
- [X] Description of the tests scenarios is included (see #46)