### PR TITLE
WIP: Move CustomConfig* tests to the separate Maven test execution

### DIFF
--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -48,4 +48,53 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+
+    <profiles>
+        <profile>
+            <id>metrics-default</id>
+            <activation>
+                <property>
+                    <name>!skip-metrics-default</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
+                    <executions>
+                        <execution>
+                            <id>default-test</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                            <configuration>
+                                <excludes>
+                                    <exclude>org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceTest.java</exclude>
+                                    <exclude>org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceProviderTest.java</exclude>
+                                </excludes>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>two-test</id>
+                            <phase>integration-test</phase>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                            <configuration>
+                                <includes>
+                                    <include>org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceTest.java</include>
+                                    <include>org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceProviderTest.java</include>
+                                </includes>
+                            </configuration>
+                        </execution>
+                    </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceTest.java
+++ b/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceTest.java
@@ -69,21 +69,23 @@ public class CustomMetricCustomConfigSourceTest extends CustomMetricDynamicBaseT
         public void setup() throws Exception {
             try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
                 client.execute(String.format("/system-property=%s:add(value=%s)", CustomConfigSource.FILEPATH_PROPERTY,
-                        CustomMetricCustomConfigSourceProviderTest.SetupTask.class.getResource(PROPERTY_FILENAME).getPath()));
+                        SetupTask.class.getResource(PROPERTY_FILENAME).getPath())).assertSuccess();
                 ModuleUtil.add(TEST_MODULE_NAME)
                         .setModuleXMLPath(SetupTask.class.getResource("configSourceModule.xml").getPath())
                         .addResource("config-source", CustomConfigSource.class)
                         .executeOn(client);
                 client.execute(String.format(
                         "/subsystem=microprofile-config-smallrye/config-source=cs-from-class:add(class={module=%s, name=%s})",
-                        TEST_MODULE_NAME, CustomConfigSource.class.getName()));
+                        TEST_MODULE_NAME, CustomConfigSource.class.getName())).assertSuccess();
             }
         }
 
         @Override
         public void tearDown() throws Exception {
             try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
-                client.execute("/subsystem=microprofile-config-smallrye/config-source=cs-from-class:remove");
+                client.execute(String.format("/system-property=%s:remove", CustomConfigSource.FILEPATH_PROPERTY))
+                        .assertSuccess();
+                client.execute("/subsystem=microprofile-config-smallrye/config-source=cs-from-class:remove").assertSuccess();
                 ModuleUtil.remove(TEST_MODULE_NAME).executeOn(client);
             }
         }


### PR DESCRIPTION
Hi @istraka 

After some MP Config studying and Metrics failures [1] investigation I tried to fix those failures, though I'm not quite sure whether this is the correct way.

So the main issue was the unset `config.source.properties.path` system property. I added the existing SetupTask class to the ServerSetup annotation to all failing test cases.

I'd like to hear your opinions regarding the solution (and maybe another ones) from you, guys - @istraka @fabiobrz, thanks!

[1] -https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-testsuite/jdk=oracle-java-11,label_exp=RHEL7/353/#showFailuresLink

Passing job - https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-testsuite/jdk=oracle-java-11,label_exp=RHEL7/355/

Please make sure your PR meets the following requirements:
- [X] Pull Request contains a description of the changes
- [X] Pull Request does not include fixes for multiple issues/topics
- [X] Code is formatted, imports ordered, code compiles and tests are passing
- [X] Link to the passing job is provided
- [X] Code is self-descriptive and/or documented
- [X] Description of the tests scenarios is included (see #46)