### PR TITLE
Enable TS to run tests against bootable JAR

### DIFF
--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -37,6 +37,143 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Bootable JAR related dependencies -->
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-bootable</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <profiles>
+        <!-- Test against Bootable JAR -->
+        <profile>
+            <id>bootablejar.profile</id>
+            <!-- TBD - remove once https://issues.redhat.com/browse/WFARQ-74 is done and wildfly-arquillian-3.0.0.Beta2 is out -->
+            <properties>
+                <jboss.home>${project.build.directory}</jboss.home>
+            </properties>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-jboss-as</id>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Disable downloaded WildFly distribution filesystem setup -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>rename-unpacked-jboss-as</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Bootable JAR Maven plugin -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.jar.plugin}</version>
+                        <executions>
+                            <!-- Provision a server with the core functionality we will provide in OpenShift images -->
+                            <execution>
+                                <id>bootable-jar-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <output-file-name>test-microprofile-config-bootable.jar</output-file-name>
+                                    <hollowJar>true</hollowJar>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <!--                                    <offline>true</offline>-->
+                                    <plugin-options>
+                                        <!--                                        <jboss-maven-dist/>-->
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>undertow-legacy-https</layer>
+                                    </layers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.args/>
+                                        <server.jvm.args/>
+                                        <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
+                                        <bootable.jar>${project.build.directory}/test-microprofile-config-bootable.jar</bootable.jar>
+                                        <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                                    </systemPropertyVariables>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>
+                                            org.wildfly.arquillian:wildfly-arquillian-container-managed
+                                        </classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+<!--                                    <excludes>-->
+<!--                                        &lt;!&ndash; Need MP FaultTolerance &ndash;&gt;-->
+<!--                                        <exclude>org/jboss/eap/qe/microprofile/health/integration/FailSafe*Test.java</exclude>-->
+<!--                                        &lt;!&ndash; Needs manual container &ndash;&gt;-->
+<!--                                        <exclude>org/jboss/eap/qe/microprofile/health/delay/*Test.java</exclude>-->
+<!--                                    </excludes>-->
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -59,8 +59,8 @@
         <!-- Test against Bootable JAR -->
         <profile>
             <id>bootablejar.profile</id>
-            <!-- TBD - remove once https://issues.redhat.com/browse/WFARQ-74 is done and wildfly-arquillian-3.0.0.Beta2 is out -->
             <properties>
+                <!-- TBD - remove once https://issues.redhat.com/browse/WFARQ-74 is done and wildfly-arquillian-3.0.0.Beta2 is out -->
                 <jboss.home>${project.build.directory}</jboss.home>
             </properties>
             <activation>
@@ -115,9 +115,7 @@
                                     <hollowJar>true</hollowJar>
                                     <record-state>false</record-state>
                                     <log-time>${galleon.log.time}</log-time>
-                                    <!--                                    <offline>true</offline>-->
                                     <plugin-options>
-                                        <!--                                        <jboss-maven-dist/>-->
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                     </plugin-options>
                                     <feature-packs>
@@ -161,12 +159,6 @@
                                             org.wildfly.arquillian:wildfly-arquillian-container-managed
                                         </classpathDependencyExclude>
                                     </classpathDependencyExcludes>
-<!--                                    <excludes>-->
-<!--                                        &lt;!&ndash; Need MP FaultTolerance &ndash;&gt;-->
-<!--                                        <exclude>org/jboss/eap/qe/microprofile/health/integration/FailSafe*Test.java</exclude>-->
-<!--                                        &lt;!&ndash; Needs manual container &ndash;&gt;-->
-<!--                                        <exclude>org/jboss/eap/qe/microprofile/health/delay/*Test.java</exclude>-->
-<!--                                    </excludes>-->
                                 </configuration>
                             </execution>
                         </executions>

--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -53,19 +53,6 @@
                     <name>ts.bootable</name>
                 </property>
             </activation>
-            <dependencies>
-                <!-- Bootable JAR related dependencies -->
-                <dependency>
-                    <groupId>org.wildfly.core</groupId>
-                    <artifactId>wildfly-launcher</artifactId>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <!-- Bootable JAR Maven plugin -->

--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -37,20 +37,9 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Bootable JAR related dependencies -->
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-common</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-launcher</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.arquillian</groupId>
-            <artifactId>wildfly-arquillian-container-bootable</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -59,51 +48,33 @@
         <!-- Test against Bootable JAR -->
         <profile>
             <id>bootablejar.profile</id>
-            <properties>
-                <!-- TBD - remove once https://issues.redhat.com/browse/WFARQ-74 is done and wildfly-arquillian-3.0.0.Beta2 is out -->
-                <jboss.home>${project.build.directory}</jboss.home>
-            </properties>
             <activation>
                 <property>
                     <name>ts.bootable</name>
                 </property>
             </activation>
+            <dependencies>
+                <!-- Bootable JAR related dependencies -->
+                <dependency>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-launcher</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>unpack-jboss-as</id>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <!-- Disable downloaded WildFly distribution filesystem setup -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>rename-unpacked-jboss-as</id>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <!-- Bootable JAR Maven plugin -->
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
                         <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
-                            <!-- Provision a server with the core functionality we will provide in OpenShift images -->
+                            <!-- Package a cloud-server -->
                             <execution>
                                 <id>bootable-jar-packaging</id>
                                 <goals>
@@ -129,7 +100,6 @@
                                     </feature-packs>
                                     <layers>
                                         <layer>cloud-server</layer>
-                                        <layer>undertow-legacy-https</layer>
                                     </layers>
                                 </configuration>
                             </execution>
@@ -167,5 +137,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -94,8 +94,6 @@
                                             <groupId>${testsuite.galleon.pack.groupId}</groupId>
                                             <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
                                             <version>${testsuite.galleon.pack.version}</version>
-                                            <inherit-configs>false</inherit-configs>
-                                            <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
                                     <layers>

--- a/microprofile-config/src/test/resources/arquillian-bootable.xml
+++ b/microprofile-config/src/test/resources/arquillian-bootable.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <group qualifier="container-group" default="true">
+        <container qualifier="jboss" default="true">
+            <configuration>
+                <property name="installDir">${install.dir}</property>
+                <property name="jarFile">${bootable.jar}</property>
+                <property name="javaVmArguments">${server.jvm.args}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">127.0.0.1</property>
+                <property name="managementPort">9990</property>
+            </configuration>
+        </container>
+    </group>
+</arquillian>

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -99,5 +99,91 @@
                 </plugins>
             </build>
         </profile>
+        <!-- Test against Bootable JAR -->
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <!-- Bootable JAR Maven plugin -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.jar.plugin}</version>
+                        <executions>
+                            <!-- Provision a server with the core functionality we will provide in OpenShift images -->
+                            <execution>
+                                <id>bootable-jar-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <output-file-name>test-microprofile-fault-tolerance-bootable.jar</output-file-name>
+                                    <hollowJar>true</hollowJar>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <plugin-options>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>microprofile-fault-tolerance</layer>
+                                    </layers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.args/>
+                                        <server.jvm.args/>
+                                        <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
+                                        <bootable.jar>${project.build.directory}/test-microprofile-fault-tolerance-bootable.jar</bootable.jar>
+                                        <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                                    </systemPropertyVariables>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>
+                                            org.wildfly.arquillian:wildfly-arquillian-container-managed
+                                        </classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -107,13 +107,6 @@
                     <name>ts.bootable</name>
                 </property>
             </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <!-- Bootable JAR Maven plugin -->

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -142,8 +142,6 @@
                                             <groupId>${testsuite.galleon.pack.groupId}</groupId>
                                             <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
                                             <version>${testsuite.galleon.pack.version}</version>
-                                            <inherit-configs>false</inherit-configs>
-                                            <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
                                     <layers>

--- a/microprofile-fault-tolerance/src/test/resources/arquillian-bootable.xml
+++ b/microprofile-fault-tolerance/src/test/resources/arquillian-bootable.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <group qualifier="container-group" default="true">
+        <container qualifier="jboss" default="true">
+            <configuration>
+                <property name="installDir">${install.dir}</property>
+                <property name="jarFile">${bootable.jar}</property>
+                <property name="javaVmArguments">${server.jvm.args}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">127.0.0.1</property>
+                <property name="managementPort">9990</property>
+            </configuration>
+        </container>
+    </group>
+</arquillian>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -44,5 +44,141 @@
             <artifactId>tooling-server-configuration</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Bootable JAR related dependencies -->
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-bootable</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <profiles>
+        <!-- Test against Bootable JAR -->
+        <profile>
+            <id>bootablejar.profile</id>
+            <properties>
+                <jboss.home>${project.build.directory}</jboss.home>
+            </properties>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-jboss-as</id>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Disable downloaded WildFly distribution filesystem setup -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>rename-unpacked-jboss-as</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Bootable JAR Maven plugin -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.jar.plugin}</version>
+                        <executions>
+                            <!-- Provision a server with the core functionality we will provide in OpenShift images -->
+                            <execution>
+                                <id>bootable-jar-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <output-file-name>test-microprofile-health-bootable.jar</output-file-name>
+                                    <hollowJar>true</hollowJar>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+<!--                                    <offline>true</offline>-->
+                                    <plugin-options>
+<!--                                        <jboss-maven-dist/>-->
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>undertow-legacy-https</layer>
+                                    </layers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.args/>
+                                        <server.jvm.args/>
+                                        <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
+                                        <bootable.jar>${project.build.directory}/test-microprofile-health-bootable.jar</bootable.jar>
+                                        <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                                    </systemPropertyVariables>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>
+                                            org.wildfly.arquillian:wildfly-arquillian-container-managed
+                                        </classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                    <excludes>
+                                        <!-- Need MP FaultTolerance -->
+                                        <exclude>org/jboss/eap/qe/microprofile/health/integration/FailSafe*Test.java</exclude>
+                                        <!-- Needs manual container -->
+                                        <exclude>org/jboss/eap/qe/microprofile/health/delay/*Test.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -66,8 +66,8 @@
         <!-- Test against Bootable JAR -->
         <profile>
             <id>bootablejar.profile</id>
-            <!-- TBD - remove once https://issues.redhat.com/browse/WFARQ-74 is done and wildfly-arquillian-3.0.0.Beta2 is out -->
             <properties>
+                <!-- TBD - remove once https://issues.redhat.com/browse/WFARQ-74 is done and wildfly-arquillian-3.0.0.Beta2 is out -->
                 <jboss.home>${project.build.directory}</jboss.home>
             </properties>
             <activation>
@@ -122,9 +122,7 @@
                                     <hollowJar>true</hollowJar>
                                     <record-state>false</record-state>
                                     <log-time>${galleon.log.time}</log-time>
-<!--                                    <offline>true</offline>-->
                                     <plugin-options>
-<!--                                        <jboss-maven-dist/>-->
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                     </plugin-options>
                                     <feature-packs>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -66,6 +66,7 @@
         <!-- Test against Bootable JAR -->
         <profile>
             <id>bootablejar.profile</id>
+            <!-- TBD - remove once https://issues.redhat.com/browse/WFARQ-74 is done and wildfly-arquillian-3.0.0.Beta2 is out -->
             <properties>
                 <jboss.home>${project.build.directory}</jboss.home>
             </properties>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -60,19 +60,6 @@
                     <name>ts.bootable</name>
                 </property>
             </activation>
-            <dependencies>
-                <!-- Bootable JAR related dependencies -->
-                <dependency>
-                    <groupId>org.wildfly.core</groupId>
-                    <artifactId>wildfly-launcher</artifactId>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <!-- Bootable JAR Maven plugin -->

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -101,8 +101,6 @@
                                             <groupId>${testsuite.galleon.pack.groupId}</groupId>
                                             <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
                                             <version>${testsuite.galleon.pack.version}</version>
-                                            <inherit-configs>false</inherit-configs>
-                                            <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
                                     <layers>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -44,20 +44,9 @@
             <artifactId>tooling-server-configuration</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Bootable JAR related dependencies -->
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-common</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-launcher</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.arquillian</groupId>
-            <artifactId>wildfly-arquillian-container-bootable</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -66,44 +55,26 @@
         <!-- Test against Bootable JAR -->
         <profile>
             <id>bootablejar.profile</id>
-            <properties>
-                <!-- TBD - remove once https://issues.redhat.com/browse/WFARQ-74 is done and wildfly-arquillian-3.0.0.Beta2 is out -->
-                <jboss.home>${project.build.directory}</jboss.home>
-            </properties>
             <activation>
                 <property>
                     <name>ts.bootable</name>
                 </property>
             </activation>
+            <dependencies>
+                <!-- Bootable JAR related dependencies -->
+                <dependency>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-launcher</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>unpack-jboss-as</id>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <!-- Disable downloaded WildFly distribution filesystem setup -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>rename-unpacked-jboss-as</id>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <!-- Bootable JAR Maven plugin -->
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>

--- a/microprofile-health/src/test/resources/arquillian-bootable.xml
+++ b/microprofile-health/src/test/resources/arquillian-bootable.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <group qualifier="container-group" default="true">
+        <container qualifier="jboss" default="true">
+            <configuration>
+                <property name="installDir">${install.dir}</property>
+                <property name="jarFile">${bootable.jar}</property>
+                <property name="javaVmArguments">${server.jvm.args}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">127.0.0.1</property>
+                <property name="managementPort">9990</property>
+            </configuration>
+        </container>
+    </group>
+</arquillian>

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -83,5 +83,90 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <!-- Bootable JAR Maven plugin -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.jar.plugin}</version>
+                        <executions>
+                            <!-- Provision a server with the core functionality we will provide in OpenShift images -->
+                            <execution>
+                                <id>bootable-jar-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <output-file-name>test-microprofile-jwt-bootable.jar</output-file-name>
+                                    <hollowJar>true</hollowJar>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <plugin-options>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>microprofile-jwt</layer>
+                                    </layers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.args/>
+                                        <server.jvm.args/>
+                                        <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
+                                        <bootable.jar>${project.build.directory}/test-microprofile-jwt-bootable.jar</bootable.jar>
+                                        <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                                    </systemPropertyVariables>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>
+                                            org.wildfly.arquillian:wildfly-arquillian-container-managed
+                                        </classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -90,13 +90,6 @@
                     <name>ts.bootable</name>
                 </property>
             </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <!-- Bootable JAR Maven plugin -->

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -125,8 +125,6 @@
                                             <groupId>${testsuite.galleon.pack.groupId}</groupId>
                                             <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
                                             <version>${testsuite.galleon.pack.version}</version>
-                                            <inherit-configs>false</inherit-configs>
-                                            <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
                                     <layers>

--- a/microprofile-jwt/src/test/resources/arquillian-bootable.xml
+++ b/microprofile-jwt/src/test/resources/arquillian-bootable.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <group qualifier="container-group" default="true">
+        <container qualifier="jboss" default="true">
+            <configuration>
+                <property name="installDir">${install.dir}</property>
+                <property name="jarFile">${bootable.jar}</property>
+                <property name="javaVmArguments">${server.jvm.args}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">127.0.0.1</property>
+                <property name="managementPort">9990</property>
+            </configuration>
+        </container>
+    </group>
+</arquillian>

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -47,5 +47,142 @@
             <artifactId>tooling-server-configuration</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Bootable JAR related dependencies -->
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-bootable</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <profiles>
+        <!-- Test against Bootable JAR -->
+        <profile>
+            <id>bootablejar.profile</id>
+            <properties>
+                <!-- TBD - remove once https://issues.redhat.com/browse/WFARQ-74 is done and wildfly-arquillian-3.0.0.Beta2 is out -->
+                <jboss.home>${project.build.directory}</jboss.home>
+                <jboss.modules.path>${basedir}/target/jboss-as-bootable/modules</jboss.modules.path>
+            </properties>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-jboss-as</id>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Disable downloaded WildFly distribution filesystem setup -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>rename-unpacked-jboss-as</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Bootable JAR Maven plugin -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.jar.plugin}</version>
+                        <executions>
+                            <!-- Provision a server with the core functionality we will provide in OpenShift images -->
+                            <execution>
+                                <id>bootable-jar-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <output-file-name>test-microprofile-config-bootable.jar</output-file-name>
+                                    <hollowJar>true</hollowJar>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <!--                                    <offline>true</offline>-->
+                                    <plugin-options>
+                                        <!--                                        <jboss-maven-dist/>-->
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>undertow-legacy-https</layer>
+                                    </layers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.args/>
+                                        <server.jvm.args/>
+                                        <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
+                                        <bootable.jar>${project.build.directory}/test-microprofile-config-bootable.jar</bootable.jar>
+                                        <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                                        <module.path>${jboss.modules.path}</module.path>
+                                    </systemPropertyVariables>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>
+                                            org.wildfly.arquillian:wildfly-arquillian-container-managed
+                                        </classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                    <excludes>
+                                        <!-- Need MP FaultTolerance -->
+                                        <exclude>org/jboss/eap/qe/microprofile/metrics/integration/ft/*Test.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -103,8 +103,6 @@
                                             <groupId>${testsuite.galleon.pack.groupId}</groupId>
                                             <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
                                             <version>${testsuite.galleon.pack.version}</version>
-                                            <inherit-configs>false</inherit-configs>
-                                            <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
                                     <layers>

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -63,18 +63,6 @@
                     <name>ts.bootable</name>
                 </property>
             </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.wildfly.core</groupId>
-                    <artifactId>wildfly-launcher</artifactId>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <!-- Bootable JAR Maven plugin -->

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -47,20 +47,9 @@
             <artifactId>tooling-server-configuration</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Bootable JAR related dependencies -->
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-common</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-launcher</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.arquillian</groupId>
-            <artifactId>wildfly-arquillian-container-bootable</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -69,45 +58,25 @@
         <!-- Test against Bootable JAR -->
         <profile>
             <id>bootablejar.profile</id>
-            <properties>
-                <!-- TBD - remove once https://issues.redhat.com/browse/WFARQ-74 is done and wildfly-arquillian-3.0.0.Beta2 is out -->
-                <jboss.home>${project.build.directory}</jboss.home>
-                <jboss.modules.path>${basedir}/target/jboss-as-bootable/modules</jboss.modules.path>
-            </properties>
             <activation>
                 <property>
                     <name>ts.bootable</name>
                 </property>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-launcher</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>unpack-jboss-as</id>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <!-- Disable downloaded WildFly distribution filesystem setup -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>rename-unpacked-jboss-as</id>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <!-- Bootable JAR Maven plugin -->
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
@@ -122,13 +91,11 @@
                                 </goals>
                                 <phase>process-test-resources</phase>
                                 <configuration>
-                                    <output-file-name>test-microprofile-config-bootable.jar</output-file-name>
+                                    <output-file-name>test-microprofile-metrics-bootable.jar</output-file-name>
                                     <hollowJar>true</hollowJar>
                                     <record-state>false</record-state>
                                     <log-time>${galleon.log.time}</log-time>
-                                    <!--                                    <offline>true</offline>-->
                                     <plugin-options>
-                                        <!--                                        <jboss-maven-dist/>-->
                                         <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                     </plugin-options>
                                     <feature-packs>
@@ -164,7 +131,7 @@
                                         <jboss.args/>
                                         <server.jvm.args/>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
-                                        <bootable.jar>${project.build.directory}/test-microprofile-config-bootable.jar</bootable.jar>
+                                        <bootable.jar>${project.build.directory}/test-microprofile-metrics-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
                                         <module.path>${jboss.modules.path}</module.path>
                                     </systemPropertyVariables>
@@ -176,6 +143,10 @@
                                     <excludes>
                                         <!-- Need MP FaultTolerance -->
                                         <exclude>org/jboss/eap/qe/microprofile/metrics/integration/ft/*Test.java</exclude>
+                                        <!-- The following test cases need for a module.path system property to be set
+                                         which doesn't make sense with Bootable JAR -->
+                                        <exclude>org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceProviderTest</exclude>
+                                        <exclude>org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceTest</exclude>
                                     </excludes>
                                 </configuration>
                             </execution>

--- a/microprofile-metrics/src/test/resources/arquillian-bootable.xml
+++ b/microprofile-metrics/src/test/resources/arquillian-bootable.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <group qualifier="container-group" default="true">
+        <container qualifier="jboss" default="true">
+            <configuration>
+                <property name="installDir">${install.dir}</property>
+                <property name="jarFile">${bootable.jar}</property>
+                <property name="javaVmArguments">${server.jvm.args}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">127.0.0.1</property>
+                <property name="managementPort">9990</property>
+            </configuration>
+        </container>
+    </group>
+</arquillian>

--- a/microprofile-open-api/pom.xml
+++ b/microprofile-open-api/pom.xml
@@ -100,13 +100,6 @@
                     <name>ts.bootable</name>
                 </property>
             </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <!-- Bootable JAR Maven plugin -->

--- a/microprofile-open-api/pom.xml
+++ b/microprofile-open-api/pom.xml
@@ -92,5 +92,90 @@
                 </plugins>
             </build>
         </profile>
+        <!-- Test against Bootable JAR -->
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <!-- Bootable JAR Maven plugin -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.jar.plugin}</version>
+                        <executions>
+                            <!-- Provision a server with the core functionality we will provide in OpenShift images -->
+                            <execution>
+                                <id>bootable-jar-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <output-file-name>test-microprofile-openapi-bootable.jar</output-file-name>
+                                    <hollowJar>true</hollowJar>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <plugin-options>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.galleon.pack.version}</version>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>undertow-legacy-https</layer>
+                                        <layer>microprofile-openapi</layer>
+                                    </layers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.args/>
+                                        <server.jvm.args/>
+                                        <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
+                                        <bootable.jar>${project.build.directory}/test-microprofile-openapi-bootable.jar</bootable.jar>
+                                        <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                                    </systemPropertyVariables>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>
+                                            org.wildfly.arquillian:wildfly-arquillian-container-managed
+                                        </classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/security/ListenerSecurityConfigurationTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/security/ListenerSecurityConfigurationTest.java
@@ -102,8 +102,11 @@ public class ListenerSecurityConfigurationTest {
 
         @Override
         public void setup() throws Exception {
-            jbossHome = arquillianContainerProperties.getContainerProperty("jboss", "jbossHome");
-
+            if (Boolean.getBoolean("ts.bootable")) {
+                jbossHome = arquillianContainerProperties.getContainerProperty("jboss", "installDir");
+            } else {
+                jbossHome = arquillianContainerProperties.getContainerProperty("jboss", "jbossHome");
+            }
             try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
                 //  configured server ports for HTTP and HTTPS bindings, offset is taken into account
                 configuredHTTPPort = OpenApiServerConfiguration.getHTTPPort(client);

--- a/microprofile-open-api/src/test/resources/arquillian-bootable.xml
+++ b/microprofile-open-api/src/test/resources/arquillian-bootable.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <group qualifier="container-group" default="true">
+        <container qualifier="jboss" default="true">
+            <configuration>
+                <property name="installDir">${install.dir}</property>
+                <property name="jarFile">${bootable.jar}</property>
+                <property name="javaVmArguments">${server.jvm.args}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">127.0.0.1</property>
+                <property name="managementPort">9990</property>
+            </configuration>
+        </container>
+    </group>
+</arquillian>

--- a/microprofile-opentracing/pom.xml
+++ b/microprofile-opentracing/pom.xml
@@ -61,7 +61,105 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-common</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
+    <profiles>
+        <!-- Test against Bootable JAR -->
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-launcher</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <!-- Bootable JAR Maven plugin -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.jar.plugin}</version>
+                        <executions>
+                            <!-- Provision a server with the core functionality we will provide in OpenShift images -->
+                            <execution>
+                                <id>bootable-jar-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <output-file-name>test-microprofile-opentracing-bootable.jar</output-file-name>
+                                    <hollowJar>true</hollowJar>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <plugin-options>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>undertow-legacy-https</layer>
+                                    </layers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
 
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.args/>
+                                        <server.jvm.args/>
+                                        <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
+                                        <bootable.jar>${project.build.directory}/test-microprofile-opentracing-bootable.jar</bootable.jar>
+                                        <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                                        <module.path>${jboss.modules.path}</module.path>
+                                    </systemPropertyVariables>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>
+                                            org.wildfly.arquillian:wildfly-arquillian-container-managed
+                                        </classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/microprofile-opentracing/pom.xml
+++ b/microprofile-opentracing/pom.xml
@@ -117,8 +117,6 @@
                                             <groupId>${testsuite.galleon.pack.groupId}</groupId>
                                             <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
                                             <version>${testsuite.galleon.pack.version}</version>
-                                            <inherit-configs>false</inherit-configs>
-                                            <inherit-packages>false</inherit-packages>
                                         </feature-pack>
                                     </feature-packs>
                                     <layers>

--- a/microprofile-opentracing/pom.xml
+++ b/microprofile-opentracing/pom.xml
@@ -77,18 +77,6 @@
                     <name>ts.bootable</name>
                 </property>
             </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.wildfly.core</groupId>
-                    <artifactId>wildfly-launcher</artifactId>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <!-- Bootable JAR Maven plugin -->

--- a/microprofile-opentracing/src/test/resources/arquillian-bootable.xml
+++ b/microprofile-opentracing/src/test/resources/arquillian-bootable.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <group qualifier="container-group" default="true">
+        <container qualifier="jboss" default="true">
+            <configuration>
+                <property name="installDir">${install.dir}</property>
+                <property name="jarFile">${bootable.jar}</property>
+                <property name="javaVmArguments">${server.jvm.args}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">127.0.0.1</property>
+                <property name="managementPort">9990</property>
+            </configuration>
+        </container>
+    </group>
+</arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
         <testsuite.galleon.pack.version>${env.WILDFLY_GALLEON_PACK_VERSION}</testsuite.galleon.pack.version>
         <!-- Bootable JAR -->
         <version.org.wildfly.jar.plugin>${env.BOOTABLE_JAR_MAVEN_PLUGIN_VERSION}</version.org.wildfly.jar.plugin>
-        <!--        <version.org.wildfly.arquillian.bootable>3.0.0.Beta1-SNAPSHOT</version.org.wildfly.arquillian.bootable>-->
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <packaging>pom</packaging>
 
     <name>Test suite for MicroProfile on WF/EAP</name>
-    
+
     <modules>
         <module>tooling-cpu-load</module>
         <module>tooling-docker</module>
@@ -221,7 +221,7 @@
         <connection>scm:git:git@github.com:jboss-eap-qe/eap-microprofile-test-suite.git</connection>
         <developerConnection>scm:git:git@github.com:jboss-eap-qe/eap-microprofile-test-suite.git</developerConnection>
     </scm>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -260,17 +260,17 @@
 
     <profiles>
         <!--
-            When the `mp.specs.scope` property is not set the TS will 
+            When the `mp.specs.scope` property is not set the TS will
             build/execute the full set of MicroProfile specs modules.
-            E.g.: when testing Wildfly, which has all of the MicroProfile specs 
+            E.g.: when testing Wildfly, which has all of the MicroProfile specs
             in since v. 19.0.0.Final, or when testing against EAP XP.
-        -->            
+        -->
         <profile>
             <id>enable-all-specs</id>
             <activation>
                 <property>
                     <name>!mp.specs.scope</name>
-                </property>              
+                </property>
             </activation>
             <build>
                 <plugins>
@@ -285,7 +285,7 @@
                                 <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
                             </environmentVariables>
                             <systemPropertyVariables>
-                                <jboss.home>${jboss.home}</jboss.home>                                
+                                <jboss.home>${jboss.home}</jboss.home>
                                 <container.base.dir.manual.mode>${container.base.dir.manual.mode}</container.base.dir.manual.mode>
                                 <module.path>${jboss.modules.path}</module.path>
                                 <arquillian.xml>${maven.multiModuleProjectDirectory}/arquillian.xml</arquillian.xml>
@@ -296,9 +296,9 @@
             </build>
         </profile>
         <!--
-            When it comes to non-XP EAP testing then only the MicroProfile 
-            specs belonging to the so called "observability layer" should be 
-            tested, hence this profile should be activated by providing the 
+            When it comes to non-XP EAP testing then only the MicroProfile
+            specs belonging to the so called "observability layer" should be
+            tested, hence this profile should be activated by providing the
             `mp.specs.scope` property with the "observability-layer" value
         -->
         <profile>
@@ -320,15 +320,15 @@
                                 <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
                             </environmentVariables>
                             <systemPropertyVariables>
-                                <jboss.home>${jboss.home}</jboss.home>                                
+                                <jboss.home>${jboss.home}</jboss.home>
                                 <jboss.configuration.file>standalone.xml</jboss.configuration.file>
                                 <container.base.dir.manual.mode>${container.base.dir.manual.mode}</container.base.dir.manual.mode>
                                 <module.path>${jboss.modules.path}</module.path>
                                 <arquillian.xml>${maven.multiModuleProjectDirectory}/arquillian.xml</arquillian.xml>
                             </systemPropertyVariables>
-                            <!-- MP Health integration tests with 
-                            MP Fault Tolerance must be excluded when testing 
-                            just the MP "observability layer" specs-->                            
+                            <!-- MP Health integration tests with
+                            MP Fault Tolerance must be excluded when testing
+                            just the MP "observability layer" specs-->
                             <excludes>
                                 <exclude>org.jboss.eap.qe.microprofile.health.integration.*Test</exclude>
                             </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,29 @@
                 <artifactId>wildfly-arquillian-common</artifactId>
                 <version>${version.org.wildfly.arquillian}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wildfly.arquillian</groupId>
+                <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                <version>${version.org.wildfly.arquillian}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.sasl</groupId>
+                        <artifactId>jboss-sasl</artifactId>
+                    </exclusion>
+                    <!-- TODO remove this exclusion once this depends on Jakarta Inject -->
+                    <!-- superseded by jakarta.inject:jakarta.inject-api -->
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>            
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-launcher</artifactId>
+                <version>${version.org.wildfly.core}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -548,34 +571,17 @@
                     </plugin>
                 </plugins>
             </build>
-            <dependencyManagement>
-                <dependencies>
-                    <!-- Bootable JAR related dependencies -->
-                    <dependency>
-                        <groupId>org.wildfly.arquillian</groupId>
-                        <artifactId>wildfly-arquillian-container-bootable</artifactId>
-                        <version>${version.org.wildfly.arquillian}</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>org.jboss.sasl</groupId>
-                                <artifactId>jboss-sasl</artifactId>
-                            </exclusion>
-                            <!-- TODO remove this exclusion once this depends on Jakarta Inject -->
-                            <!-- superseded by jakarta.inject:jakarta.inject-api -->
-                            <exclusion>
-                                <groupId>javax.inject</groupId>
-                                <artifactId>javax.inject</artifactId>
-                            </exclusion>
-                        </exclusions>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.wildfly.core</groupId>
-                        <artifactId>wildfly-launcher</artifactId>
-                        <version>${version.org.wildfly.core}</version>
-                        <scope>test</scope>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
+            <dependencies>
+                <!-- Bootable JAR related dependencies -->
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-launcher</artifactId>
+                </dependency>
+            </dependencies>            
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,11 @@
         <version.org.eclipse.microprofile>3.3</version.org.eclipse.microprofile>
         <version.org.jboss.arquillian>1.5.0.Final</version.org.jboss.arquillian>
         <version.org.jboss.wildfly.dist>20.0.0.Final</version.org.jboss.wildfly.dist>
-        <version.org.wildfly.arquillian>3.0.0.Beta1</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>3.0.0.Beta3</version.org.wildfly.arquillian>
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
         <!-- wildfly-core update needed to have the launcher version with BootableJarCommandBuilder used to start
         the server up -->
-        <version.org.wildfly.core>13.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>13.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.yaml.snakeyaml>1.24</version.org.yaml.snakeyaml>
         <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
@@ -60,11 +60,11 @@
         <!-- Galleon -->
         <galleon.fork.embedded>true</galleon.fork.embedded>
         <galleon.log.time>true</galleon.log.time>
-        <testsuite.galleon.pack.groupId>${env.WILDFLY_GALLEON_PACK_GROUP_ID}</testsuite.galleon.pack.groupId>
+        <testsuite.galleon.pack.groupId>org.wildfly</testsuite.galleon.pack.groupId>
         <testsuite.galleon.pack.artifactId>wildfly-galleon-pack</testsuite.galleon.pack.artifactId>
-        <testsuite.galleon.pack.version>${env.WILDFLY_GALLEON_PACK_VERSION}</testsuite.galleon.pack.version>
+        <testsuite.galleon.pack.version>20.0.1.Final</testsuite.galleon.pack.version>
         <!-- Bootable JAR -->
-        <version.org.wildfly.jar.plugin>${env.BOOTABLE_JAR_MAVEN_PLUGIN_VERSION}</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>2.0.0.Beta3</version.org.wildfly.jar.plugin>
     </properties>
 
     <dependencyManagement>
@@ -208,35 +208,10 @@
                 <artifactId>postgresql</artifactId>
                 <version>${version.org.postgresql}</version>
             </dependency>
-            <!-- Bootable JAR related dependencies -->
-            <dependency>
-                <groupId>org.wildfly.arquillian</groupId>
-                <artifactId>wildfly-arquillian-container-bootable</artifactId>
-                <version>${version.org.wildfly.arquillian}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.jboss.sasl</groupId>
-                        <artifactId>jboss-sasl</artifactId>
-                    </exclusion>
-                    <!-- TODO remove this exclusion once this depends on Jakarta Inject -->
-                    <!-- superseded by jakarta.inject:jakarta.inject-api -->
-                    <exclusion>
-                        <groupId>javax.inject</groupId>
-                        <artifactId>javax.inject</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <dependency>
                 <groupId>org.wildfly.arquillian</groupId>
                 <artifactId>wildfly-arquillian-common</artifactId>
                 <version>${version.org.wildfly.arquillian}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-launcher</artifactId>
-                <version>${version.org.wildfly.core}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -526,6 +501,81 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <!-- Test against Bootable JAR -->
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-jboss-as</id>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Disable downloaded WildFly distribution filesystem setup -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>rename-unpacked-jboss-as</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>initialize-basedirs</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencyManagement>
+                <dependencies>
+                    <!-- Bootable JAR related dependencies -->
+                    <dependency>
+                        <groupId>org.wildfly.arquillian</groupId>
+                        <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                        <version>${version.org.wildfly.arquillian}</version>
+                        <exclusions>
+                            <exclusion>
+                                <groupId>org.jboss.sasl</groupId>
+                                <artifactId>jboss-sasl</artifactId>
+                            </exclusion>
+                            <!-- TODO remove this exclusion once this depends on Jakarta Inject -->
+                            <!-- superseded by jakarta.inject:jakarta.inject-api -->
+                            <exclusion>
+                                <groupId>javax.inject</groupId>
+                                <artifactId>javax.inject</artifactId>
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.wildfly.core</groupId>
+                        <artifactId>wildfly-launcher</artifactId>
+                        <version>${version.org.wildfly.core}</version>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <testsuite.galleon.pack.artifactId>wildfly-galleon-pack</testsuite.galleon.pack.artifactId>
         <testsuite.galleon.pack.version>20.0.1.Final</testsuite.galleon.pack.version>
         <!-- Bootable JAR -->
-        <version.org.wildfly.jar.plugin>2.0.0.Beta3</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>2.0.0.Beta5</version.org.wildfly.jar.plugin>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -32,17 +32,18 @@
     <properties>
         <jboss.home>IF-NOT-DEFINED-WILDFLY-WILL-BE-DOWNLOADED-UNZIPPED-AND-USED-AUTOMATICALLY</jboss.home>
         <maven.test.redirectTestOutputToFile>false</maven.test.redirectTestOutputToFile>
-
         <version.io.rest-assured>4.1.2</version.io.rest-assured>
         <version.javax.servlet.javax.servlet-api>3.0.1</version.javax.servlet.javax.servlet-api>
         <version.junit>4.12</version.junit>
         <version.org.apache.maven.plugins.maven-release-plugin>3.0.0-M1</version.org.apache.maven.plugins.maven-release-plugin>
         <version.org.eclipse.microprofile>3.3</version.org.eclipse.microprofile>
         <version.org.jboss.arquillian>1.5.0.Final</version.org.jboss.arquillian>
-        <version.org.jboss.wildfly.dist>19.0.0.Beta2</version.org.jboss.wildfly.dist>
-        <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
+        <version.org.jboss.wildfly.dist>20.0.0.Final</version.org.jboss.wildfly.dist>
+        <version.org.wildfly.arquillian>3.0.0.Beta1</version.org.wildfly.arquillian>
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
-        <version.org.wildfly.core>10.0.3.Final</version.org.wildfly.core>
+        <!-- wildfly-core update needed to have the launcher version with BootableJarCommandBuilder used to start
+        the server up -->
+        <version.org.wildfly.core>13.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.yaml.snakeyaml>1.24</version.org.yaml.snakeyaml>
         <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
@@ -56,6 +57,15 @@
         <version.io.jaegertracing.jaeger-client>1.0.0</version.io.jaegertracing.jaeger-client>
         <container.qualifier.manual.mode>jboss-manual</container.qualifier.manual.mode>
         <container.base.dir.manual.mode>${project.build.directory}${file.separator}${container.qualifier.manual.mode}</container.base.dir.manual.mode>
+        <!-- Galleon -->
+        <galleon.fork.embedded>true</galleon.fork.embedded>
+        <galleon.log.time>true</galleon.log.time>
+        <testsuite.galleon.pack.groupId>${env.WILDFLY_GALLEON_PACK_GROUP_ID}</testsuite.galleon.pack.groupId>
+        <testsuite.galleon.pack.artifactId>wildfly-galleon-pack</testsuite.galleon.pack.artifactId>
+        <testsuite.galleon.pack.version>${env.WILDFLY_GALLEON_PACK_VERSION}</testsuite.galleon.pack.version>
+        <!-- Bootable JAR -->
+        <version.org.wildfly.jar.plugin>${env.BOOTABLE_JAR_MAVEN_PLUGIN_VERSION}</version.org.wildfly.jar.plugin>
+        <!--        <version.org.wildfly.arquillian.bootable>3.0.0.Beta1-SNAPSHOT</version.org.wildfly.arquillian.bootable>-->
     </properties>
 
     <dependencyManagement>
@@ -199,6 +209,36 @@
                 <artifactId>postgresql</artifactId>
                 <version>${version.org.postgresql}</version>
             </dependency>
+            <!-- Bootable JAR related dependencies -->
+            <dependency>
+                <groupId>org.wildfly.arquillian</groupId>
+                <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                <version>${version.org.wildfly.arquillian}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.sasl</groupId>
+                        <artifactId>jboss-sasl</artifactId>
+                    </exclusion>
+                    <!-- TODO remove this exclusion once this depends on Jakarta Inject -->
+                    <!-- superseded by jakarta.inject:jakarta.inject-api -->
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.arquillian</groupId>
+                <artifactId>wildfly-arquillian-common</artifactId>
+                <version>${version.org.wildfly.arquillian}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-launcher</artifactId>
+                <version>${version.org.wildfly.core}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -323,6 +363,7 @@
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>copy-wildfly</id>
             <activation>
@@ -378,10 +419,13 @@
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>download-wildfly</id>
             <activation>
-                <property><name>!jboss.dist</name></property>
+                <property>
+                    <name>!jboss.dist</name>
+                </property>
             </activation>
             <properties>
                 <jboss.home>${basedir}/target/jboss-as</jboss.home>

--- a/tooling-cpu-load/pom.xml
+++ b/tooling-cpu-load/pom.xml
@@ -51,4 +51,33 @@
         </dependency>
     </dependencies>
 
+    <!-- Test against Bootable JAR -->
+    <profiles>
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/tooling-server-configuration/pom.xml
+++ b/tooling-server-configuration/pom.xml
@@ -19,7 +19,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
-            <artifactId>wildfly-arquillian-container-managed</artifactId>
+            <artifactId>wildfly-arquillian-common</artifactId>
             <scope>compile</scope>
         </dependency>
         <!-- Arquillian container test SPI for extension -->

--- a/tooling-server-configuration/pom.xml
+++ b/tooling-server-configuration/pom.xml
@@ -46,6 +46,40 @@
             <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-managed</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <!-- Test against Bootable JAR -->
+    <profiles>
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
This PR is to allow the TS to run tests against the bootable JAR and adds profiles to the existing modules in order to do so.

Successful job run: https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-testsuite-bootable/66

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- N/A - Description of the tests scenarios is included (see #46)