### PR TITLE
Add server reload in order to apply config-source changes

### DIFF
--- a/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceProviderTest.java
+++ b/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceProviderTest.java
@@ -20,6 +20,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 
 /**
  * MP Config property is provided by ConfigSource class provided by custom provider - CustomConfigSourceProvider.
@@ -78,16 +79,20 @@ public class CustomMetricCustomConfigSourceProviderTest extends CustomMetricDyna
                         .executeOn(client);
                 client.execute(String.format(
                         "/subsystem=microprofile-config-smallrye/config-source-provider=cs-from-provider:add(class={module=%s, name=%s})",
-                        TEST_MODULE_NAME, CustomConfigSourceProvider.class.getName()));
+                        TEST_MODULE_NAME, CustomConfigSourceProvider.class.getName())).assertSuccess();
             }
         }
 
         @Override
         public void tearDown() throws Exception {
             try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
-                client.execute(String.format("/system-property=%s:remove", CustomConfigSource.FILEPATH_PROPERTY));
-                client.execute("/subsystem=microprofile-config-smallrye/config-source-provider=cs-from-provider:remove");
+                client.execute(String.format("/system-property=%s:remove", CustomConfigSource.FILEPATH_PROPERTY))
+                        .assertSuccess();
+                client.execute("/subsystem=microprofile-config-smallrye/config-source-provider=cs-from-provider:remove")
+                        .assertSuccess();
                 ModuleUtil.remove(TEST_MODULE_NAME).executeOn(client);
+                // reload server in order to apply changes
+                new Administration(client).reload();
             }
         }
     }

--- a/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceTest.java
+++ b/microprofile-metrics/src/test/java/org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceTest.java
@@ -20,6 +20,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 
 /**
  * MP Config property is provided by ConfigSource.
@@ -69,22 +70,26 @@ public class CustomMetricCustomConfigSourceTest extends CustomMetricDynamicBaseT
         public void setup() throws Exception {
             try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
                 client.execute(String.format("/system-property=%s:add(value=%s)", CustomConfigSource.FILEPATH_PROPERTY,
-                        CustomMetricCustomConfigSourceProviderTest.SetupTask.class.getResource(PROPERTY_FILENAME).getPath()));
+                        SetupTask.class.getResource(PROPERTY_FILENAME).getPath())).assertSuccess();
                 ModuleUtil.add(TEST_MODULE_NAME)
                         .setModuleXMLPath(SetupTask.class.getResource("configSourceModule.xml").getPath())
                         .addResource("config-source", CustomConfigSource.class)
                         .executeOn(client);
                 client.execute(String.format(
                         "/subsystem=microprofile-config-smallrye/config-source=cs-from-class:add(class={module=%s, name=%s})",
-                        TEST_MODULE_NAME, CustomConfigSource.class.getName()));
+                        TEST_MODULE_NAME, CustomConfigSource.class.getName())).assertSuccess();
             }
         }
 
         @Override
         public void tearDown() throws Exception {
             try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
-                client.execute("/subsystem=microprofile-config-smallrye/config-source=cs-from-class:remove");
+                client.execute(String.format("/system-property=%s:remove", CustomConfigSource.FILEPATH_PROPERTY))
+                        .assertSuccess();
+                client.execute("/subsystem=microprofile-config-smallrye/config-source=cs-from-class:remove").assertSuccess();
                 ModuleUtil.remove(TEST_MODULE_NAME).executeOn(client);
+                // reload server in order to apply changes
+                new Administration(client).reload();
             }
         }
     }


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFLY-13779

Changes: 
1) Add assertSuccess() checks to every client.execute() line
2) Reload server in order to modify existing config-source associated to a ClassLoader (more details in WFLY-13779 commentaries).

Passing job link: https://eap-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-7.x-microprofile-testsuite/361/jdk=oracle-java-11,label_exp=RHEL7/

cc @jbliznak 

Please make sure your PR meets the following requirements:
- [X] Pull Request contains a description of the changes
- [X] Pull Request does not include fixes for multiple issues/topics
- [X] Code is formatted, imports ordered, code compiles and tests are passing
- [X] Link to the passing job is provided
- [X] Code is self-descriptive and/or documented
- [X] Description of the tests scenarios is included (see #46)