### PR TITLE
[WFLY-12342][JBEAP-19987] Add server probes for readiness health check

### DIFF
--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/DefaultReadinessProcedureHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/DefaultReadinessProcedureHealthTest.java
@@ -5,19 +5,29 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientHelper.executeCliCommand;
 
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.http.HttpStatus;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.eap.qe.microprofile.health.tools.HealthUrlProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientRelatedException;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -37,6 +47,7 @@ import io.restassured.http.ContentType;
 public class DefaultReadinessProcedureHealthTest {
 
     public static final String ARCHIVE_NAME = DefaultReadinessProcedureHealthTest.class.getSimpleName() + ".war";
+    private final String CHANGE_H2_DRIVER_NAME_CLI = "/subsystem=datasources/data-source=ExampleDS:write-attribute(name=driver-name, value=%s)";
 
     @Deployment(testable = false)
     public static Archive<?> deployment() {
@@ -47,24 +58,30 @@ public class DefaultReadinessProcedureHealthTest {
 
     /**
      * @tpTestDetails Calls the deprecated {@code health} endpoint to get response from all health check procedures
-     * @tpPassCrit Overall health check status is up and two checks are expected to be returned: one {@code liveness}
+     * @tpPassCrit Overall health check status is up and five checks are expected to be returned: one {@code liveness}
      *             check - which is defined by the {@link LivenessHealthCheck} annotated class and has "UP" status and data -
      *             and
      *             one {@code readiness} check - which is provided by Wildfly because none was defined in the deployment and the
      *             {@code mp.health.disable-default-procedures} being set to {@code false} by default. This last check must be
      *             conventionally named after the deplyment name - i.e namely: {@code "ready-deployment." + deployment name}
+     *             With WFLY-12342 There was also added {@code deployments-status}, {@code boot-errors}, {@code server-state}
+     *             checks
      * @tpSince EAP 7.4.0.CD19
      */
     @Test
     public void testHealthEndpoint() throws ConfigurationException {
         RestAssured.get(HealthUrlProvider.healthEndpoint()).then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
                 .contentType(ContentType.JSON)
                 .body("status", is("UP"),
-                        "checks", hasSize(2),
+                        "checks", hasSize(5),
                         "checks.status", hasItems("UP", "UP"),
-                        "checks.name", containsInAnyOrder(String.format("ready-deployment.%s", ARCHIVE_NAME), "live"),
-                        "checks.data", hasSize(2),
-                        "checks.data.key", contains("value"));
+                        "checks.name",
+                        containsInAnyOrder("deployments-status", "boot-errors", "server-state",
+                                String.format("ready-deployment.%s", ARCHIVE_NAME), "live"),
+                        "checks.data", hasSize(5),
+                        "checks.find{it.name == 'live'}.data.key", is("value"));
     }
 
     /**
@@ -89,7 +106,7 @@ public class DefaultReadinessProcedureHealthTest {
 
     /**
      * @tpTestDetails Calls the {@code ready} endpoint to get response from all {@code readiness} procedures
-     * @tpPassCrit Overall health check status is up and one check is expected to be returned, i.e the {@code readiness}
+     * @tpPassCrit Overall health check status is up and four check are expected to be returned, i.e the {@code readiness}
      *             check which is provided by Wildfly because none was defined in the deployment and the
      *             {@code mp.health.disable-default-procedures} being set to {@code false} by default. It must be
      *             conventionally named after the deplyment name - i.e namely: {@code "ready-deployment." + deployment name}
@@ -97,12 +114,99 @@ public class DefaultReadinessProcedureHealthTest {
      */
     @Test
     public void testReadinessEndpoint() throws ConfigurationException {
+        String readyDeploymentCheckName = String.format("ready-deployment.%s", ARCHIVE_NAME);
         RestAssured.get(HealthUrlProvider.readyEndpoint()).then()
                 .contentType(ContentType.JSON)
                 .body("status", is("UP"),
-                        "checks", hasSize(1),
+                        "checks", hasSize(4),
                         "checks.status", hasItems("UP"),
-                        "checks.name", contains(String.format("ready-deployment.%s", ARCHIVE_NAME)),
-                        "checks.data", contains(nullValue()));
+                        "checks.name",
+                        containsInAnyOrder("boot-errors", "server-state", "deployments-status",
+                                readyDeploymentCheckName),
+                        "checks.find{it.name == '" + readyDeploymentCheckName + "'}.data", is(nullValue()),
+                        "checks.find{it.name == 'boot-errors'}.data", is(nullValue()),
+                        "checks.find{it.name == 'deployments-status'}.data", is(notNullValue()),
+                        "checks.find{it.name == 'server-state'}.data.value", is("running"));
+    }
+
+    /**
+     * @tpTestDetails Calls the {@code ready} endpoint to get response from all {@code readiness} procedures. We have
+     *                introduced change which switch server to {@code reload-required} change.
+     * @tpPassCrit Overall health check status is down and {@code server-state} readiness check is DOWN
+     * @tpSince EAP 7.4.0.CD21
+     */
+    @Test
+    public void testServerStateDown() throws ConfigurationException, IOException, ManagementClientRelatedException {
+        OnlineManagementClient client = ManagementClientProvider.onlineStandalone();
+        try {
+            executeCliCommand(client, String.format(CHANGE_H2_DRIVER_NAME_CLI, "wrong_driver_name"));
+
+            RestAssured.get(HealthUrlProvider.readyEndpoint()).then()
+                    .contentType(ContentType.JSON)
+                    .body("status", is("DOWN"),
+                            "checks.find{it.name == 'server-state'}.status", is("DOWN"),
+                            "checks.find{it.name == 'deployments-status'}.status", is("UP"),
+                            "checks.find{it.name == 'boot-errors'}.status", is("UP"),
+                            "checks.find{it.name == 'server-state'}.data.value", is("reload-required"));
+
+        } finally {
+            // put back configuration to correct form
+            executeCliCommand(client, String.format(CHANGE_H2_DRIVER_NAME_CLI, "h2"));
+            client.close();
+        }
+    }
+
+    /**
+     * @tpTestDetails Calls the {@code ready} endpoint to get response from all {@code readiness} procedures. Wrong
+     *                configuration change is introduced which emits exception in server start
+     * @tpPassCrit Overall health check status is down and {@code boot-errors} readiness check is DOWN
+     * @tpSince EAP 7.4.0.CD21
+     */
+    @Test
+    public void testBootErrorsDown() throws ConfigurationException, IOException, ManagementClientRelatedException,
+            TimeoutException, InterruptedException {
+        OnlineManagementClient client = ManagementClientProvider.onlineStandalone();
+        try {
+            executeCliCommand(client, String.format(CHANGE_H2_DRIVER_NAME_CLI, "wrong_driver_name"));
+            new Administration(client).reloadIfRequired();
+
+            RestAssured.get(HealthUrlProvider.readyEndpoint()).then()
+                    .contentType(ContentType.JSON)
+                    .body("status", is("DOWN"),
+                            "checks.find{it.name == 'boot-errors'}.status", is("DOWN"),
+                            "checks.find{it.name == 'server-state'}.status", is("UP"),
+                            "checks.find{it.name == 'deployments-status'}.status", is("DOWN"),
+                            "checks.find{it.name == 'boot-errors'}.data", is(notNullValue()));
+        } finally {
+            // put back configuration to correct form
+            executeCliCommand(client, String.format(CHANGE_H2_DRIVER_NAME_CLI, "h2"));
+            new Administration(client).reloadIfRequired();
+            client.close();
+        }
+    }
+
+    /**
+     * @tpTestDetails Calls the {@code ready} endpoint to get response from all {@code readiness} procedures. There is
+     *                one STOPPED deployment which cause deployments-status to be DOWN.
+     * @tpPassCrit Overall health check status is down and {@code deployments-status} readiness check is DOWN
+     * @tpSince EAP 7.4.0.CD21
+     */
+    @Test
+    public void testDeploymentsStatusDown() throws ConfigurationException, IOException, ManagementClientRelatedException {
+        OnlineManagementClient client = ManagementClientProvider.onlineStandalone();
+        try {
+            executeCliCommand(client, "deployment disable " + ARCHIVE_NAME);
+
+            RestAssured.get(HealthUrlProvider.readyEndpoint()).then()
+                    .contentType(ContentType.JSON)
+                    .body("status", is("DOWN"),
+                            "checks.find{it.name == 'deployments-status'}.status", is("DOWN"),
+                            "checks.find{it.name == 'server-state'}.status", is("UP"),
+                            "checks.find{it.name == 'boot-errors'}.status", is("UP"),
+                            "checks.find{it.name == 'deployments-status'}.data", is(notNullValue()));
+        } finally {
+            executeCliCommand(client, "deployment enable " + ARCHIVE_NAME);
+            client.close();
+        }
     }
 }

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/DisableDefaultHealthProceduresSetupTask.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/DisableDefaultHealthProceduresSetupTask.java
@@ -1,0 +1,32 @@
+package org.jboss.eap.qe.microprofile.health;
+
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
+
+/**
+ * Add system property {@code MP_HEALTH_DISABLE_DEFAULT_PROCEDURES} for MP Health to disable vendor specific checks
+ */
+public class DisableDefaultHealthProceduresSetupTask implements MicroProfileServerSetupTask {
+
+    public static final String MP_HEALTH_DISABLE_DEFAULT_PROCEDURES = "mp.health.disable-default-procedures";
+
+    @Override
+    public void setup() throws Exception {
+        try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+            client.execute(String.format("/system-property=%s:add(value=true)", MP_HEALTH_DISABLE_DEFAULT_PROCEDURES))
+                    .assertSuccess();
+            new Administration(client).reload();
+        }
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+            client.execute(String.format("/system-property=%s:remove", MP_HEALTH_DISABLE_DEFAULT_PROCEDURES))
+                    .assertSuccess();
+            new Administration(client).reload();
+        }
+    }
+}

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/HealthDeprecatedTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/HealthDeprecatedTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.is;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.tools.HealthUrlProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.shrinkwrap.api.Archive;
@@ -23,6 +24,7 @@ import io.restassured.http.ContentType;
 
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup({ DisableDefaultHealthProceduresSetupTask.class })
 public class HealthDeprecatedTest {
 
     @Deployment(testable = false)

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/HealthNullTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/HealthNullTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.is;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.tools.HealthUrlProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.shrinkwrap.api.Archive;
@@ -22,6 +23,7 @@ import io.restassured.http.ContentType;
 
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup({ DisableDefaultHealthProceduresSetupTask.class })
 public class HealthNullTest {
 
     @Deployment(testable = false)

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/HealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/HealthTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.not;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.tools.HealthUrlProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.shrinkwrap.api.Archive;
@@ -24,6 +25,7 @@ import io.restassured.http.ContentType;
 
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup({ DisableDefaultHealthProceduresSetupTask.class })
 public class HealthTest {
 
     @Deployment(testable = false)

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MimeTypeHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MimeTypeHealthTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.not;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.tools.HealthUrlProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.shrinkwrap.api.Archive;
@@ -24,6 +25,7 @@ import io.restassured.http.ContentType;
 
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup({ DisableDefaultHealthProceduresSetupTask.class })
 public class MimeTypeHealthTest {
 
     @Deployment(testable = false)

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MultiDeploymentHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MultiDeploymentHealthTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.not;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.tools.HealthUrlProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.shrinkwrap.api.Archive;
@@ -26,6 +27,7 @@ import io.restassured.http.ContentType;
  * Multiple deployment scenario.
  */
 @RunWith(Arquillian.class)
+@ServerSetup({ DisableDefaultHealthProceduresSetupTask.class })
 public class MultiDeploymentHealthTest {
 
     @Deployment(name = "deployment1", order = 1, testable = false)

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/SimplifiedHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/SimplifiedHealthTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.not;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.tools.HealthUrlProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.shrinkwrap.api.Archive;
@@ -24,6 +25,7 @@ import io.restassured.http.ContentType;
 
 @RunAsClient
 @RunWith(Arquillian.class)
+@ServerSetup({ DisableDefaultHealthProceduresSetupTask.class })
 public class SimplifiedHealthTest {
 
     @Deployment(testable = false)

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/delay/NotReadyHealthCheckTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/delay/NotReadyHealthCheckTest.java
@@ -248,7 +248,8 @@ public class NotReadyHealthCheckTest {
                 get(HealthUrlProvider.readyEndpoint(arqProps)).then()
                         .statusCode(503)
                         .body("status", is("DOWN"),
-                                "checks.name", containsInAnyOrder(DelayedReadinessHealthCheck.NAME));
+                                "checks.name", containsInAnyOrder(DelayedReadinessHealthCheck.NAME, "deployments-status",
+                                        "boot-errors", "server-state"));
             } finally {
                 controller.stop(ManualTests.ARQUILLIAN_CONTAINER);
             }
@@ -300,7 +301,8 @@ public class NotReadyHealthCheckTest {
                         .statusCode(200)
                         .body("status", is("UP"),
                                 "checks.name", containsInAnyOrder(
-                                        "ready-deployment." + DelayedLivenessHealthCheck.class.getSimpleName() + ".war"));
+                                        "ready-deployment." + DelayedLivenessHealthCheck.class.getSimpleName() + ".war",
+                                        "deployments-status", "boot-errors", "server-state"));
             } finally {
                 controller.stop(ManualTests.ARQUILLIAN_CONTAINER);
             }

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/delay/ReadinessChecker.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/delay/ReadinessChecker.java
@@ -51,20 +51,20 @@ public class ReadinessChecker implements Callable<Boolean> {
                         if (response.getStatusCode() == 503) {
                             if (checks == null) {
                                 addState(DOWN_NO_CONTENT());
-                            } else if (checks.size() == 0) {
+                            } else if ((checks.size() == 4) && contains(checks, "empty-readiness-checks")) {
                                 addState(DOWN_NO_CHECK());
-                            } else if (checks.get(0).get("name").equals(DelayedReadinessHealthCheck.NAME)) {
+                            } else if ((checks.size() == 4) && contains(checks, DelayedReadinessHealthCheck.NAME)) {
                                 addState(ReadinessState.DOWN_WITH_CHECK());
                             }
                         } else if (response.getStatusCode() == 200) {
                             if (checks == null) {
                                 throw new RuntimeException("Readiness probe is UP (200) however missing JSON content");
                             }
-                            if (checks.size() == 0) {
+                            if ((checks.size() == 4) && contains(checks, "empty-readiness-checks")) {
                                 addState(UP_NO_CHECK());
-                            } else if (checks.get(0).get("name").equals(DelayedReadinessHealthCheck.NAME)) {
+                            } else if ((checks.size() == 4) && contains(checks, DelayedReadinessHealthCheck.NAME)) {
                                 addState(UP_WITH_CHECK());
-                            } else if (checks.get(0).get("name").startsWith(DEFAULT_READINESS_CHECK_NAME_PREFIX)) {
+                            } else if ((checks.size() == 4) && contains(checks, DEFAULT_READINESS_CHECK_NAME_PREFIX)) {
                                 addState(UP_WITH_DEFAULT_CHECK());
                             }
                         }
@@ -90,6 +90,23 @@ public class ReadinessChecker implements Callable<Boolean> {
 
     private int lastIndexOfStates() {
         return states.size() - 1;
+    }
+
+    /**
+     * @param list collection to find in
+     * @param key which we are looking for
+     * @return true if key {@code name} atribute startsWith {@code key}. False otherwise.
+     */
+    private boolean contains(List<Map<String, String>> list, String key) {
+        if (list == null) {
+            return false;
+        }
+        for (Map<String, String> item : list) {
+            if (item.get("name").startsWith(key)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void stop() {

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDICustomConfigSourceHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDICustomConfigSourceHealthTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.health.DisableDefaultHealthProceduresSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.ModuleUtil;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
@@ -24,7 +25,8 @@ import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({ MicroProfileFTSetupTask.class, FailSafeCDICustomConfigSourceHealthTest.SetupTask.class })
+@ServerSetup({ DisableDefaultHealthProceduresSetupTask.class, MicroProfileFTSetupTask.class,
+        FailSafeCDICustomConfigSourceHealthTest.SetupTask.class })
 public class FailSafeCDICustomConfigSourceHealthTest extends FailSafeCDIHealthDynamicBaseTest {
     private static final String PROPERTY_FILENAME = "health.properties";
     Path propertyFile = Paths.get(FailSafeCDICustomConfigSourceHealthTest.class.getResource(PROPERTY_FILENAME).getPath());

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDICustomConfigSourceProviderHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDICustomConfigSourceProviderHealthTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.health.DisableDefaultHealthProceduresSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.ModuleUtil;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
@@ -24,7 +25,8 @@ import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({ MicroProfileFTSetupTask.class, FailSafeCDICustomConfigSourceProviderHealthTest.SetupTask.class })
+@ServerSetup({ DisableDefaultHealthProceduresSetupTask.class, MicroProfileFTSetupTask.class,
+        FailSafeCDICustomConfigSourceProviderHealthTest.SetupTask.class })
 public class FailSafeCDICustomConfigSourceProviderHealthTest extends FailSafeCDIHealthDynamicBaseTest {
     private static final String PROPERTY_FILENAME = "health.properties";
     Path propertyFile = Paths.get(

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIModelFilePropsHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIModelFilePropsHealthTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.health.DisableDefaultHealthProceduresSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.junit.After;
@@ -25,7 +26,8 @@ import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({ MicroProfileFTSetupTask.class, FailSafeCDIModelFilePropsHealthTest.SetupTask.class })
+@ServerSetup({ DisableDefaultHealthProceduresSetupTask.class, MicroProfileFTSetupTask.class,
+        FailSafeCDIModelFilePropsHealthTest.SetupTask.class })
 public class FailSafeCDIModelFilePropsHealthTest extends FailSafeCDIHealthBaseTest {
 
     private byte[] liveFileBytes;

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIModelPropsHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIModelPropsHealthTest.java
@@ -3,6 +3,7 @@ package org.jboss.eap.qe.microprofile.health.integration;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.health.DisableDefaultHealthProceduresSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.junit.runner.RunWith;
@@ -16,7 +17,8 @@ import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({ MicroProfileFTSetupTask.class, FailSafeCDIModelPropsHealthTest.SetupTask.class })
+@ServerSetup({ DisableDefaultHealthProceduresSetupTask.class, MicroProfileFTSetupTask.class,
+        FailSafeCDIModelPropsHealthTest.SetupTask.class })
 public class FailSafeCDIModelPropsHealthTest extends FailSafeCDIHealthBaseTest {
 
     @Override

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDISystemPropertyHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDISystemPropertyHealthTest.java
@@ -3,6 +3,7 @@ package org.jboss.eap.qe.microprofile.health.integration;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.health.DisableDefaultHealthProceduresSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.junit.runner.RunWith;
@@ -16,7 +17,8 @@ import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup({ MicroProfileFTSetupTask.class, FailSafeCDISystemPropertyHealthTest.SetupTask.class })
+@ServerSetup({ DisableDefaultHealthProceduresSetupTask.class, MicroProfileFTSetupTask.class,
+        FailSafeCDISystemPropertyHealthTest.SetupTask.class })
 public class FailSafeCDISystemPropertyHealthTest extends FailSafeCDIHealthBaseTest {
 
     @Override


### PR DESCRIPTION
This is just a backport of https://github.com/jboss-eap-qe/eap-microprofile-test-suite/pull/223

Changes related to JBEAP-19987:
- adjust existing tests to work with new changes
- added new tests for new fetures in JBEAP-19987

CI run: https://eap-cp-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/eap-73x-microprofile-testsuite/39/

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)