### PR TITLE
Allow to use podman via system property even without docker bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
  
  Maven is not a hard requirement as `mvnw` is delivered with this repository.
 
- Podman with docker command bridge can be used as a Docker alternative.
+ Podman with docker command bridge can be used as a Docker alternative or you can use a system property `-Ddocker.command=podman`.
 
 ## Run the testsuite
 ```

--- a/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/Docker.java
+++ b/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/Docker.java
@@ -37,6 +37,8 @@ public class Docker extends ExternalResource {
     private ExecutorService outputPrinter;
     private Process dockerRunProcess;
 
+    public static final String DOCKER_CMD = System.getProperty("docker.command", "docker");
+
     private Docker() {
     } // avoid instantiation, use Builder
 
@@ -46,7 +48,7 @@ public class Docker extends ExternalResource {
 
         List<String> cmd = new ArrayList<>();
 
-        cmd.add("docker");
+        cmd.add(DOCKER_CMD);
         cmd.add("run");
         cmd.add("--name");
         cmd.add(uuid);
@@ -121,7 +123,7 @@ public class Docker extends ExternalResource {
     private void checkDockerPresent() throws Exception {
         Process dockerInfoProcess = new ProcessBuilder()
                 .redirectErrorStream(true)
-                .command(new String[] { "docker", "info" })
+                .command(new String[] { DOCKER_CMD, "info" })
                 .start();
         dockerInfoProcess.waitFor();
         if (dockerInfoProcess.exitValue() != 0) {
@@ -136,7 +138,7 @@ public class Docker extends ExternalResource {
     public boolean isRunning() throws Exception {
         Process dockerRunProcess = new ProcessBuilder()
                 .redirectErrorStream(true)
-                .command(new String[] { "docker", "ps" })
+                .command(new String[] { DOCKER_CMD, "ps" })
                 .start();
 
         dockerRunProcess.waitFor();
@@ -161,7 +163,7 @@ public class Docker extends ExternalResource {
                 .a(" with ID ").fgYellow().a(uuid).reset());
 
         new ProcessBuilder()
-                .command("docker", "stop", uuid)
+                .command(DOCKER_CMD, "stop", uuid)
                 .start()
                 .waitFor(10, TimeUnit.SECONDS);
         terminateThreadPools();
@@ -173,7 +175,7 @@ public class Docker extends ExternalResource {
                 .a(" with ID ").fgYellow().a(uuid).reset());
 
         new ProcessBuilder()
-                .command("docker", "kill", uuid)
+                .command(DOCKER_CMD, "kill", uuid)
                 .start()
                 .waitFor(10, TimeUnit.SECONDS);
         terminateThreadPools();
@@ -187,7 +189,7 @@ public class Docker extends ExternalResource {
 
     private void removeDockerContainer() throws Exception {
         new ProcessBuilder()
-                .command("docker", "rm", uuid)
+                .command(DOCKER_CMD, "rm", uuid)
                 .start()
                 .waitFor(10, TimeUnit.SECONDS);
     }
@@ -262,7 +264,7 @@ public class Docker extends ExternalResource {
         /**
          * Adds options into starting docker command.
          * <p>
-         * See "docker run --help" for full list of options
+         * See "<docker_command> run --help" for full list of options
          *
          * @param option additional docker parameters
          */

--- a/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/MalformedDockerConfigTest.java
+++ b/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/MalformedDockerConfigTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.not;
+import static org.jboss.eap.qe.ts.common.docker.Docker.DOCKER_CMD;
 
 import java.util.concurrent.TimeUnit;
 
@@ -26,7 +27,7 @@ public class MalformedDockerConfigTest {
                         .build();
 
         thrown.expect(DockerException.class);
-        thrown.expectMessage(containsString("Starting of docker container using command: \"docker run --name"));
+        thrown.expectMessage(containsString("Starting of docker container using command: \"" + DOCKER_CMD + " run --name"));
         thrown.expectMessage(endsWith("failed. Check that provided command is correct."));
 
         containerWithInvalidVersion.start();


### PR DESCRIPTION
If you don't want/can't install docker-podman bridge and you only want to use podman you can now do so by leveraging `-Ddocker.command=podman` property.

Regression run without the property: 
* https://master-jenkins-csb-eap-qe.cloud.paas.psi.redhat.com/job/eap-7.x-microprofile-testsuite/519/
* https://master-jenkins-csb-eap-qe.cloud.paas.psi.redhat.com/job/eap-7.x-microprofile-testsuite/522/

The run with property set to podman tested on local Fedora with docker-less environment

