### PR TITLE
DatabaseCrashTest: add :Z option when mounting volumes to avoid probl…

### DIFF
--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/DatabaseCrashTest.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/DatabaseCrashTest.java
@@ -109,7 +109,7 @@ public class DatabaseCrashTest {
                 .withEnvVar("POSTGRES_DB", "test-database") // creates "test-database" database after 1st start
                 .withEnvVar("POSTGRES_PASSWORD", "pass")
                 .withCmdOption("-v")
-                .withCmdOption(postgresDataDir.getAbsolutePath() + ":/var/lib/postgresql/data")
+                .withCmdOption(postgresDataDir.getAbsolutePath() + ":/var/lib/postgresql/data:Z")
                 .withCmdOption("-u")
                 .withCmdOption(String.valueOf(new UnixSystem().getUid()))
                 .build();


### PR DESCRIPTION
…ems with SELinux

See https://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/


