### PR TITLE
Fixing microprofile-config test issues

### DIFF
--- a/microprofile-config/src/main/java/org/jboss/eap/qe/microprofile/config/testapp/jaxrs/ResolverEndPoint.java
+++ b/microprofile-config/src/main/java/org/jboss/eap/qe/microprofile/config/testapp/jaxrs/ResolverEndPoint.java
@@ -88,7 +88,7 @@ public class ResolverEndPoint {
             resolver.registerConfig(specificConfig2, ResolverEndPoint.class.getClassLoader());
             return ILLEGAL_STATE_EXCEPTION_ERROR_MESSAGE;
         } catch (IllegalStateException ise) {
-            if (!ise.getMessage().equals("Configuration already registered for the given class loader")) {
+            if (!ise.getMessage().equals("SRCFG00017: Configuration already registered for the given class loader")) {
                 return ILLEGAL_STATE_EXCEPTION_ERROR_MESSAGE;
             }
         }


### PR DESCRIPTION
This PR is to update a couple of test cases relating to MicroProfile Config which were found while testing against EAP XP3 CRs.

Actually the issues are due to the endpoint class implementation which:

* needs to be updated in order to reflect the addition of error codes to error messages in SmallRye Config implementation, see https://github.com/smallrye/smallrye-config/pull/288
* needs for the customized configuration instances life cycle to be fixed so that any failure in a test will not corrupt the deployment configuration status.

CI runs: 
* [standard profile](https://master-jenkins-csb-eap-qe.apps.ocp4.prod.psi.redhat.com/job/eap-7.x-microprofile-testsuite/577/)
* [bootable JAR profile](https://master-jenkins-csb-eap-qe.apps.ocp4.prod.psi.redhat.com/job/eap-7.x-microprofile-testsuite-bootable/208/)
Both the above runs show that the failures (one of which was depending on the first test case failure) are now gone.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)