### PR TITLE
Fix for microprofile-health-api-3.1

### DIFF
--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/DefaultReadinessProcedureHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/DefaultReadinessProcedureHealthTest.java
@@ -75,12 +75,13 @@ public class DefaultReadinessProcedureHealthTest {
                 .statusCode(HttpStatus.SC_OK)
                 .contentType(ContentType.JSON)
                 .body("status", is("UP"),
-                        "checks", hasSize(5),
+                        "checks", hasSize(6),
                         "checks.status", hasItems("UP", "UP"),
                         "checks.name",
                         containsInAnyOrder("deployments-status", "boot-errors", "server-state",
-                                String.format("ready-deployment.%s", ARCHIVE_NAME), "live"),
-                        "checks.data", hasSize(5),
+                                String.format("ready-deployment.%s", ARCHIVE_NAME),
+                                String.format("started-deployment.%s", ARCHIVE_NAME), "live"),
+                        "checks.data", hasSize(6),
                         "checks.find{it.name == 'live'}.data.key", is("value"));
     }
 


### PR DESCRIPTION
`microprofile-health-api-3.1.0` introduces a new `startup` health check;

Before `microprofile-health-api-3.1.0` the health check endpoint used to produce a response like:

```
{
    "status": "UP",
    "checks": [
        {
            "name": "empty-liveness-checks",
            "status": "UP"
        },
        {
            "name": "boot-errors",
            "status": "UP"
        },
        {
            "name": "deployments-status",
            "status": "UP"
        },
        {
            "name": "empty-readiness-checks",
            "status": "UP"
        },
        {
            "name": "server-state",
            "status": "UP",
            "data": {
                "value": "running"
            }
        }
    ]
}
```


Now it has been augmented with the startup check:

```
{
    "status": "UP",
    "checks": [
        {
            "name": "empty-liveness-checks",
            "status": "UP"
        },
        {
            "name": "boot-errors",
            "status": "UP"
        },
        {
            "name": "deployments-status",
            "status": "UP"
        },
        {
            "name": "empty-readiness-checks",
            "status": "UP"
        },
        {
            "name": "server-state",
            "status": "UP",
            "data": {
                "value": "running"
            }
        },
        {
            "name": "empty-startup-checks",
            "status": "UP"
        }
    ]
}
```


As a consequence an invocation that used to produce the following output:

```
[
"boot-errors",
"deployments-status",
"server-state",
"live",
"ready-deployment.DefaultReadinessProcedureHealthTest.war",
]
```
 

now produces:

```
[
"boot-errors",
"deployments-status",
"server-state",
"live",
"ready-deployment.DefaultReadinessProcedureHealthTest.war",
"started-deployment.DefaultReadinessProcedureHealthTest.war"
]
```


This MR modifies test `DefaultReadinessProcedureHealthTest` in order to take this into account when checking the reponse from the health endpoint;

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided: https://main-jenkins-csb-eapcpqe.apps.ocp4.prod.psi.redhat.com/job/eap-74x-microprofile-testsuite/jdk=oracle-java-11,label_exp=RHEL7&&(medium%7C%7Clarge)/16
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)