### PR TITLE
JDK17 support

### DIFF
--- a/arquillian.xml
+++ b/arquillian.xml
@@ -6,7 +6,7 @@
         <container qualifier="jboss" default="true" >
             <configuration>
                 <property name="jbossHome">${basedir}/target/jboss-as</property>
-                <property name="javaVmArguments">-server -Xms64m -Xmx512m</property>
+                <property name="javaVmArguments">-server -Xms64m -Xmx512m ${server.jvm.jpms.args}</property>
                 <property name="serverConfig">${jboss.configuration.file:standalone-microprofile.xml}</property>
                 <property name="managementAddress">127.0.0.1</property>
                 <property name="managementPort">9990</property>
@@ -19,7 +19,7 @@
         <container qualifier="jboss-manual" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jboss-as</property>
-                <property name="javaVmArguments">-server -Xms64m -Xmx256m -Djboss.socket.binding.port-offset=10000 -Djboss.server.base.dir=${container.base.dir.manual.mode}</property>
+                <property name="javaVmArguments">-server -Xms64m -Xmx256m -Djboss.socket.binding.port-offset=10000 -Djboss.server.base.dir=${container.base.dir.manual.mode} ${server.jvm.jpms.args}</property>
                 <property name="serverConfig">${jboss.configuration.file:standalone-microprofile.xml}</property>
                 <property name="managementAddress">127.0.0.1</property>
                 <property name="managementPort">19990</property>

--- a/arquillian.xml
+++ b/arquillian.xml
@@ -6,7 +6,7 @@
         <container qualifier="jboss" default="true" >
             <configuration>
                 <property name="jbossHome">${basedir}/target/jboss-as</property>
-                <property name="javaVmArguments">-server -Xms64m -Xmx512m ${server.jvm.jpms.args}</property>
+                <property name="javaVmArguments">-server -Xms64m -Xmx512m ${server.jvm.args}</property>
                 <property name="serverConfig">${jboss.configuration.file:standalone-microprofile.xml}</property>
                 <property name="managementAddress">127.0.0.1</property>
                 <property name="managementPort">9990</property>
@@ -19,7 +19,7 @@
         <container qualifier="jboss-manual" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jboss-as</property>
-                <property name="javaVmArguments">-server -Xms64m -Xmx256m -Djboss.socket.binding.port-offset=10000 -Djboss.server.base.dir=${container.base.dir.manual.mode} ${server.jvm.jpms.args}</property>
+                <property name="javaVmArguments">-server -Xms64m -Xmx256m -Djboss.socket.binding.port-offset=10000 -Djboss.server.base.dir=${container.base.dir.manual.mode} ${server.jvm.args}</property>
                 <property name="serverConfig">${jboss.configuration.file:standalone-microprofile.xml}</property>
                 <property name="managementAddress">127.0.0.1</property>
                 <property name="managementPort">19990</property>

--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -102,9 +102,8 @@
                                 </goals>
                                 <phase>test</phase>
                                 <configuration>
-                                    <systemPropertyVariables>
+                                    <systemPropertyVariables combine.children="append">
                                         <jboss.args/>
-                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-config-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -104,7 +104,7 @@
                                 <configuration>
                                     <systemPropertyVariables>
                                         <jboss.args/>
-                                        <server.jvm.args/>
+                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-config-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -157,9 +157,8 @@
                                 </goals>
                                 <phase>test</phase>
                                 <configuration>
-                                    <systemPropertyVariables>
+                                    <systemPropertyVariables combine.children="append">
                                         <jboss.args/>
-                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-fault-tolerance-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -159,7 +159,7 @@
                                 <configuration>
                                     <systemPropertyVariables>
                                         <jboss.args/>
-                                        <server.jvm.args/>
+                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-fault-tolerance-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -113,7 +113,7 @@
                                 <configuration>
                                     <systemPropertyVariables>
                                         <jboss.args/>
-                                        <server.jvm.args/>
+                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-health-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -73,9 +73,8 @@
                                 </goals>
                                 <phase>test</phase>
                                 <configuration>
-                                    <systemPropertyVariables>
+                                    <systemPropertyVariables combine.children="append">
                                         <jboss.args/>
-                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-health-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -62,6 +62,39 @@
             </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.args/>
+                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
+                                        <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
+                                        <bootable.jar>${project.build.directory}/test-microprofile-health-bootable.jar</bootable.jar>
+                                        <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                                    </systemPropertyVariables>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>
+                                            org.wildfly.arquillian:wildfly-arquillian-container-managed
+                                        </classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                    <excludes>
+                                        <!-- Need MP FaultTolerance -->
+                                        <exclude>org/jboss/eap/qe/microprofile/health/integration/FailSafe*Test.java</exclude>
+                                        <!-- Needs manual container -->
+                                        <exclude>org/jboss/eap/qe/microprofile/health/delay/*Test.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <!-- Bootable JAR Maven plugin -->
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
@@ -95,40 +128,6 @@
                                         <layer>undertow-legacy-https</layer>
                                         <layer>h2-default-datasource</layer>
                                     </layers>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>test</phase>
-                                <configuration>
-                                    <systemPropertyVariables>
-                                        <jboss.args/>
-                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
-                                        <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
-                                        <bootable.jar>${project.build.directory}/test-microprofile-health-bootable.jar</bootable.jar>
-                                        <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
-                                    </systemPropertyVariables>
-                                    <classpathDependencyExcludes>
-                                        <classpathDependencyExclude>
-                                            org.wildfly.arquillian:wildfly-arquillian-container-managed
-                                        </classpathDependencyExclude>
-                                    </classpathDependencyExcludes>
-                                    <excludes>
-                                        <!-- Need MP FaultTolerance -->
-                                        <exclude>org/jboss/eap/qe/microprofile/health/integration/FailSafe*Test.java</exclude>
-                                        <!-- Needs manual container -->
-                                        <exclude>org/jboss/eap/qe/microprofile/health/delay/*Test.java</exclude>
-                                    </excludes>
                                 </configuration>
                             </execution>
                         </executions>

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -150,9 +150,8 @@
                                 </goals>
                                 <phase>test</phase>
                                 <configuration>
-                                    <systemPropertyVariables>
+                                    <systemPropertyVariables combine.children="append">
                                         <jboss.args/>
-                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-jwt-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -152,7 +152,7 @@
                                 <configuration>
                                     <systemPropertyVariables>
                                         <jboss.args/>
-                                        <server.jvm.args/>
+                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-jwt-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -77,9 +77,8 @@
                                 </goals>
                                 <phase>test</phase>
                                 <configuration>
-                                    <systemPropertyVariables>
+                                    <systemPropertyVariables combine.children="append">
                                         <jboss.args/>
-                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-metrics-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -65,42 +65,6 @@
             </activation>
             <build>
                 <plugins>
-                    <!-- Bootable JAR Maven plugin -->
-                    <plugin>
-                        <groupId>org.wildfly.plugins</groupId>
-                        <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
-                        <executions>
-                            <!-- Provision a server with the core functionality we will provide in OpenShift images -->
-                            <execution>
-                                <id>bootable-jar-packaging</id>
-                                <goals>
-                                    <goal>package</goal>
-                                </goals>
-                                <phase>process-test-resources</phase>
-                                <configuration>
-                                    <output-file-name>test-microprofile-metrics-bootable.jar</output-file-name>
-                                    <hollowJar>true</hollowJar>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <plugin-options>
-                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                    </plugin-options>
-                                    <feature-packs>
-                                        <feature-pack>
-                                            <groupId>${testsuite.galleon.pack.groupId}</groupId>
-                                            <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
-                                            <version>${testsuite.galleon.pack.version}</version>
-                                        </feature-pack>
-                                    </feature-packs>
-                                    <layers>
-                                        <layer>cloud-server</layer>
-                                        <layer>undertow-legacy-https</layer>
-                                    </layers>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
 
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -134,6 +98,42 @@
                                         <exclude>org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceProviderTest</exclude>
                                         <exclude>org/jboss/eap/qe/microprofile/metrics/integration/config/CustomMetricCustomConfigSourceTest</exclude>
                                     </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Bootable JAR Maven plugin -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.jar.plugin}</version>
+                        <executions>
+                            <!-- Provision a server with the core functionality we will provide in OpenShift images -->
+                            <execution>
+                                <id>bootable-jar-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <output-file-name>test-microprofile-metrics-bootable.jar</output-file-name>
+                                    <hollowJar>true</hollowJar>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <plugin-options>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.galleon.pack.version}</version>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>undertow-legacy-https</layer>
+                                    </layers>
                                 </configuration>
                             </execution>
                         </executions>

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -115,7 +115,7 @@
                                 <configuration>
                                     <systemPropertyVariables>
                                         <jboss.args/>
-                                        <server.jvm.args/>
+                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-metrics-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/microprofile-open-api/pom.xml
+++ b/microprofile-open-api/pom.xml
@@ -153,7 +153,7 @@
                                 <configuration>
                                     <systemPropertyVariables>
                                         <jboss.args/>
-                                        <server.jvm.args/>
+                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-openapi-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/microprofile-open-api/pom.xml
+++ b/microprofile-open-api/pom.xml
@@ -151,9 +151,8 @@
                                 </goals>
                                 <phase>test</phase>
                                 <configuration>
-                                    <systemPropertyVariables>
+                                    <systemPropertyVariables combine.children="append">
                                         <jboss.args/>
-                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-openapi-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/microprofile-opentracing/pom.xml
+++ b/microprofile-opentracing/pom.xml
@@ -79,6 +79,34 @@
             </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.args/>
+                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
+                                        <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
+                                        <bootable.jar>${project.build.directory}/test-microprofile-opentracing-bootable.jar</bootable.jar>
+                                        <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                                        <module.path>${jboss.modules.path}</module.path>
+                                    </systemPropertyVariables>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>
+                                            org.wildfly.arquillian:wildfly-arquillian-container-managed
+                                        </classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <!-- Bootable JAR Maven plugin -->
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
@@ -111,35 +139,6 @@
                                         <layer>cloud-server</layer>
                                         <layer>undertow-legacy-https</layer>
                                     </layers>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>test</phase>
-                                <configuration>
-                                    <systemPropertyVariables>
-                                        <jboss.args/>
-                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
-                                        <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
-                                        <bootable.jar>${project.build.directory}/test-microprofile-opentracing-bootable.jar</bootable.jar>
-                                        <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
-                                        <module.path>${jboss.modules.path}</module.path>
-                                    </systemPropertyVariables>
-                                    <classpathDependencyExcludes>
-                                        <classpathDependencyExclude>
-                                            org.wildfly.arquillian:wildfly-arquillian-container-managed
-                                        </classpathDependencyExclude>
-                                    </classpathDependencyExcludes>
                                 </configuration>
                             </execution>
                         </executions>

--- a/microprofile-opentracing/pom.xml
+++ b/microprofile-opentracing/pom.xml
@@ -90,9 +90,8 @@
                                 </goals>
                                 <phase>test</phase>
                                 <configuration>
-                                    <systemPropertyVariables>
+                                    <systemPropertyVariables combine.children="append">
                                         <jboss.args/>
-                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-opentracing-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/microprofile-opentracing/pom.xml
+++ b/microprofile-opentracing/pom.xml
@@ -129,7 +129,7 @@
                                 <configuration>
                                     <systemPropertyVariables>
                                         <jboss.args/>
-                                        <server.jvm.args/>
+                                        <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
                                         <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
                                         <bootable.jar>${project.build.directory}/test-microprofile-opentracing-bootable.jar</bootable.jar>
                                         <arquillian.xml>arquillian-bootable.xml</arquillian.xml>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <version.org.awaitility>3.1.6</version.org.awaitility>
         <version.org.jboss.shrinkwrap.resolver>3.1.3</version.org.jboss.shrinkwrap.resolver>
         <version.org.postgresql>42.2.8</version.org.postgresql>
-        <version.org.apache.maven.plugins.maven-surefire-plugin>2.22.2</version.org.apache.maven.plugins.maven-surefire-plugin>
+        <version.org.apache.maven.plugins.maven-surefire-plugin>3.0.0-M6</version.org.apache.maven.plugins.maven-surefire-plugin>
         <version.io.opentracing.api>0.31.0</version.io.opentracing.api>
         <version.io.jaegertracing.jaeger-client>1.0.0</version.io.jaegertracing.jaeger-client>
         <container.qualifier.manual.mode>jboss-manual</container.qualifier.manual.mode>

--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,9 @@
         <galleon.log.time>true</galleon.log.time>
         <testsuite.galleon.pack.groupId>org.wildfly</testsuite.galleon.pack.groupId>
         <testsuite.galleon.pack.artifactId>wildfly-galleon-pack</testsuite.galleon.pack.artifactId>
-        <testsuite.galleon.pack.version>20.0.1.Final</testsuite.galleon.pack.version>
+        <testsuite.galleon.pack.version>24.0.0.Final</testsuite.galleon.pack.version>
         <!-- Bootable JAR -->
-        <version.org.wildfly.jar.plugin>2.0.0.Beta5</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>7.0.1.Final</version.org.wildfly.jar.plugin>
         <version.org.bitbucket.b_c.jose4j>0.7.4</version.org.bitbucket.b_c.jose4j>
         <!-- Modular JDK JPMS options -->
         <server.jvm.jpms.args>--add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED</server.jvm.jpms.args>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,17 @@
         </dependencies>
     </dependencyManagement>
 
+    <!--
+        The ttransitive WildFly Core Launcher pull has been excluded in dependncyManagement, we want one that
+        works with JDK17
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-launcher</artifactId>
+        </dependency>
+    </dependencies>
+
     <scm>
         <url>scm:git:git@github.com:jboss-eap-qe/eap-microprofile-test-suite.git</url>
         <connection>scm:git:git@github.com:jboss-eap-qe/eap-microprofile-test-suite.git</connection>
@@ -608,14 +619,6 @@
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-bootable</artifactId>
-                </dependency>
-                <!--
-                    It looks like container-bootable DOES NOT pull the transitive WildFly Core dependency in,
-                    (which also explains while it's defined below) so no need to exclude anything.
-                -->
-                <dependency>
-                    <groupId>org.wildfly.core</groupId>
-                    <artifactId>wildfly-launcher</artifactId>
                 </dependency>
             </dependencies>            
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
         <!-- wildfly-core update needed to have the launcher version with BootableJarCommandBuilder used to start
         the server up -->
-        <version.org.wildfly.core>13.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.0.Beta8</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.yaml.snakeyaml>1.26</version.org.yaml.snakeyaml>
         <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
@@ -119,13 +119,6 @@
                         <artifactId>wildfly-launcher</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <!-- We need to lock the WIldFly Core launcher version to let it work on JDK 17 -->
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-launcher</artifactId>
-                <version>19.0.0.Beta8</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.wildfly</groupId>
@@ -248,7 +241,7 @@
                         <artifactId>javax.inject</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>            
+            </dependency>
             <dependency>
                 <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-launcher</artifactId>
@@ -616,6 +609,10 @@
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-bootable</artifactId>
                 </dependency>
+                <!--
+                    It looks like container-bootable DOES NOT pull the transitive WildFly Core dependency in,
+                    (which also explains while it's defined below) so no need to exclude anything.
+                -->
                 <dependency>
                     <groupId>org.wildfly.core</groupId>
                     <artifactId>wildfly-launcher</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,20 @@
                 <artifactId>wildfly-arquillian-container-managed</artifactId>
                 <version>${version.org.wildfly.arquillian}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <!-- We need to avoid using the transitive WildFly Core dependency since it might not work on JDK 17 -->
+                    <exclusion>
+                        <groupId>org.wildfly.core</groupId>
+                        <artifactId>wildfly-launcher</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <!-- We need to lock the WIldFly Core launcher version to let it work on JDK 17 -->
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-launcher</artifactId>
+                <version>19.0.0.Beta8</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.wildfly</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>36</version>
+        <version>39</version>
     </parent>
 
     <groupId>org.jboss.eap.qe</groupId>
@@ -256,7 +256,7 @@
     </dependencyManagement>
 
     <!--
-        The ttransitive WildFly Core Launcher pull has been excluded in dependncyManagement, we want one that
+        The transitive WildFly Core Launcher pull has been excluded in dependencyManagement, we want one that
         works with JDK17
     -->
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,9 @@
         <!-- Bootable JAR -->
         <version.org.wildfly.jar.plugin>2.0.0.Beta5</version.org.wildfly.jar.plugin>
         <version.org.bitbucket.b_c.jose4j>0.7.4</version.org.bitbucket.b_c.jose4j>
+        <!-- Modular JDK JPMS options -->
+        <server.jvm.jpms.args>--add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED</server.jvm.jpms.args>
+        <client.jvm.jpms.args>--add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED</client.jvm.jpms.args>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,9 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
                     <configuration>
+                        <systemPropertyVariables>
+                            <server.jvm.args>${server.jvm.jpms.args}</server.jvm.args>
+                        </systemPropertyVariables>
                         <argLine>${client.jvm.jpms.args}</argLine>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <jboss.home>IF-NOT-DEFINED-WILDFLY-WILL-BE-DOWNLOADED-UNZIPPED-AND-USED-AUTOMATICALLY</jboss.home>
         <maven.test.redirectTestOutputToFile>false</maven.test.redirectTestOutputToFile>
-        <version.io.rest-assured>4.1.2</version.io.rest-assured>
+        <version.io.rest-assured>5.0.1</version.io.rest-assured>
         <version.javax.servlet.javax.servlet-api>3.0.1</version.javax.servlet.javax.servlet-api>
         <version.junit>4.13.1</version.junit>
         <version.org.apache.maven.plugins.maven-release-plugin>3.0.0-M1</version.org.apache.maven.plugins.maven-release-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,19 @@
     </scm>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
+                    <configuration>
+                        <argLine>${client.jvm.jpms.args}</argLine>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR introduces the minimum set of changes to let the TS support JDK17 executions.

JPMS options are set, both on the server (i.e. Arquillian managed instances) and client (i.e. Surefire execution) sides.
Also the Bootable JAR Plugin version has been bumped so that bootable jar applications (and deployments) have the required JMPS options in their manifest file.
A small refactoring of the Maven Surefire plugin definition has been done at the root POM level as well, to allow for better configuration.
Additionally, some dependencies' version has been updated, including the WildFly Core Launcher, which has been locked to the version working with JDK17.

One note regarding the WildFly Galleon Pack version which is used by Bootable JAR related tests: such version is now set to 24.0.0.Final, i.e. the last one supporting the `undertow-legacy-https` layer, which is used by several TS modules, e.g.: https://github.com/jboss-eap-qe/eap-microprofile-test-suite/blob/master/microprofile-health/pom.xml#L95.
In order to use latest WildFly or JBoss EAP tests, changes will be required to relace this layer with a supported one (`undertow-https`?). this effort [is tracked by a separate issue](https://github.com/jboss-eap-qe/eap-microprofile-test-suite/issues/251).

Finally, upgrading Arquillian will require additional work, and is [tracked separately](https://github.com/jboss-eap-qe/eap-microprofile-test-suite/issues/252) for this reason, outside the scope of the JDK17 mandatory changes.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- N/A - Link to the passing job is provided - internal pipeline runs have been executed and tracked
- [x] Code is self-descriptive and/or documented
- N/A - Description of the tests scenarios is included (see #46) - no tests are added