### PR TITLE
Remove observability specs profiles

### DIFF
--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -75,30 +75,6 @@
     </dependencies>
     
     <profiles>
-        <profile>
-            <id>observability-layer-modules</id>
-            <activation>
-                <property>
-                    <name>mp.specs.scope</name>
-                    <value>observability</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!-- Disable the surefire tests -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <!-- Test against Bootable JAR -->
         <profile>
             <id>bootablejar.profile</id>

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -90,30 +90,6 @@
 
     <profiles>
         <profile>
-            <id>observability-layer-modules</id>
-            <activation>
-                <property>
-                    <name>mp.specs.scope</name>
-                    <value>observability</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!-- Disable the surefire tests -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>bootablejar.profile</id>
             <activation>
                 <property>

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyselection/MultipleConfiguredPublicKeysSelectionLocationPropTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyselection/MultipleConfiguredPublicKeysSelectionLocationPropTest.java
@@ -117,7 +117,8 @@ public class MultipleConfiguredPublicKeysSelectionLocationPropTest {
      * @tpTestDetails A JWT signed by a "pink" private key is send to the server which has configured public key to be a
      *                JSON Web Key set in JSON. There are multiple keys in this set and there is no "pink" public key among
      *                them.
-     * @tpPassCrit JWt is rejected and user receives "501/internal server error" because there is no matching configured public key on
+     * @tpPassCrit JWt is rejected and user receives "501/internal server error" because there is no matching configured public
+     *             key on
      *             the server.
      * @tpSince EAP 7.4.0.CD19
      */
@@ -176,7 +177,8 @@ public class MultipleConfiguredPublicKeysSelectionLocationPropTest {
      * @tpTestDetails A JWT signed by a "pink" private key is send to the server which has configured public key to be a
      *                JSON Web Key set Base64 encoded. There are multiple keys in this set and there is no "pink" public
      *                key among them.
-     * @tpPassCrit JWt is rejected and user receives "501/internal server error" because there is no matching configured public key on
+     * @tpPassCrit JWt is rejected and user receives "501/internal server error" because there is no matching configured public
+     *             key on
      *             the server.
      * @tpSince EAP 7.4.0.CD19
      */

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyselection/MultipleConfiguredPublicKeysSelectionTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/security/keyselection/MultipleConfiguredPublicKeysSelectionTest.java
@@ -140,7 +140,8 @@ public class MultipleConfiguredPublicKeysSelectionTest {
      * @tpTestDetails A JWT signed by a "pink" private key is send to the server which has configured public key to be a
      *                JSON Web Key set in JSON. There are multiple keys in this set and there is no "pink" public key among
      *                them.
-     * @tpPassCrit JWt is rejected and user receives "501/internal server error" because there is no matching configured public key on
+     * @tpPassCrit JWt is rejected and user receives "501/internal server error" because there is no matching configured public
+     *             key on
      *             the server.
      * @tpSince EAP 7.4.0.CD19
      */
@@ -198,7 +199,8 @@ public class MultipleConfiguredPublicKeysSelectionTest {
      * @tpTestDetails A JWT signed by a "pink" private key is send to the server which has configured public key to be a
      *                JSON Web Key set Base64 encoded. There are multiple keys in this set and there is no "pink" public
      *                key among them.
-     * @tpPassCrit JWt is rejected and user receives "501/internal server error" because there is no matching configured public key on
+     * @tpPassCrit JWt is rejected and user receives "501/internal server error" because there is no matching configured public
+     *             key on
      *             the server.
      * @tpSince EAP 7.4.0.CD19
      */

--- a/microprofile-open-api/pom.xml
+++ b/microprofile-open-api/pom.xml
@@ -68,30 +68,6 @@
     </dependencies>    
     
     <profiles>
-        <profile>
-            <id>observability-layer-modules</id>
-            <activation>
-                <property>
-                    <name>mp.specs.scope</name>
-                    <value>observability</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!-- Disable the surefire tests -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>default-test</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <!-- Test against Bootable JAR -->
         <profile>
             <id>bootablejar.profile</id>

--- a/pom.xml
+++ b/pom.xml
@@ -345,89 +345,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
+                <configuration>
+                    <environmentVariables>
+                        <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                        <JAEGER_SAMPLER_PARAM>1.0</JAEGER_SAMPLER_PARAM>
+                        <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
+                    </environmentVariables>
+                    <systemPropertyVariables>
+                        <jboss.home>${jboss.home}</jboss.home>
+                        <container.base.dir.manual.mode>${container.base.dir.manual.mode}</container.base.dir.manual.mode>
+                        <module.path>${jboss.modules.path}</module.path>
+                        <arquillian.xml>${maven.multiModuleProjectDirectory}/arquillian.xml</arquillian.xml>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
     <profiles>
-        <!--
-            When the `mp.specs.scope` property is not set the TS will
-            build/execute the full set of MicroProfile specs modules.
-            E.g.: when testing Wildfly, which has all of the MicroProfile specs
-            in since v. 19.0.0.Final, or when testing against EAP XP.
-        -->
-        <profile>
-            <id>enable-all-specs</id>
-            <activation>
-                <property>
-                    <name>!mp.specs.scope</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
-                        <configuration>
-                            <environmentVariables>
-                                <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
-                                <JAEGER_SAMPLER_PARAM>1.0</JAEGER_SAMPLER_PARAM>
-                                <JAEGER_SAMPLER_TYPE>const</JAEGER_SAMPLER_TYPE>
-                            </environmentVariables>
-                            <systemPropertyVariables>
-                                <jboss.home>${jboss.home}</jboss.home>
-                                <container.base.dir.manual.mode>${container.base.dir.manual.mode}</container.base.dir.manual.mode>
-                                <module.path>${jboss.modules.path}</module.path>
-                                <arquillian.xml>${maven.multiModuleProjectDirectory}/arquillian.xml</arquillian.xml>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <!--
-            When it comes to non-XP EAP testing then only the MicroProfile
-            specs belonging to the so called "observability layer" should be
-            tested, hence this profile should be activated by providing the
-            `mp.specs.scope` property with the "observability-layer" value
-        -->
-        <profile>
-            <id>enable-observability-layer-specs</id>
-            <activation>
-                <property>
-                    <name>mp.specs.scope</name>
-                    <value>observability</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
-                        <configuration>
-                            <environmentVariables>
-                                <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
-                            </environmentVariables>
-                            <systemPropertyVariables>
-                                <jboss.home>${jboss.home}</jboss.home>
-                                <jboss.configuration.file>standalone.xml</jboss.configuration.file>
-                                <container.base.dir.manual.mode>${container.base.dir.manual.mode}</container.base.dir.manual.mode>
-                                <module.path>${jboss.modules.path}</module.path>
-                                <arquillian.xml>${maven.multiModuleProjectDirectory}/arquillian.xml</arquillian.xml>
-                            </systemPropertyVariables>
-                            <!-- MP Health integration tests with
-                            MP Fault Tolerance must be excluded when testing
-                            just the MP "observability layer" specs-->
-                            <excludes>
-                                <exclude>org.jboss.eap.qe.microprofile.health.integration.*Test</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <profile>
             <id>copy-wildfly</id>
             <activation>


### PR DESCRIPTION
A partial set of specs (observability specs) has been removed from the base EAP, and the TS should not be executed against it.
This PR is removing the Maven profiles which configure such execution.

Fix #249 


**CI runs IDs** (internal infrastructure job eap-8.x-microprofile-simple-face):
* EAP based run (no MP specs, no tests executed) - run # 78
* EAP XP based run (MP specs, tests get executed, unrelated failures are due to #251) - run # 80
* WildFly based run (MP specs, tests get executed, unrelated failures are due to #251) - run # 82

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] ~Link to~ ID of the passing job is provided
- [x] Code is self-descriptive and/or documented
- **N/A** Description of the tests scenarios is included (see #46)