### PR TITLE
Fix the JTW Keycloak integration test 

### DIFF
--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakConfigurator.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakConfigurator.java
@@ -37,6 +37,7 @@ public class KeycloakConfigurator extends ExternalResource {
         createRealmOnKeycloak(this.realmName);
         createClientOnKeycloak(this.realmName, this.clientId);
         createClientRole(this.realmName, this.clientId, "USER");
+        createGroupOnKeycloak(Roles.MONITOR);
     }
 
     @Override
@@ -90,6 +91,18 @@ public class KeycloakConfigurator extends ExternalResource {
                         .add("name", roleName)
                         .build().toString())
                 .post(this.baseApiUrl.toExternalForm() + "/admin/realms/" + realmName + "/clients/" + clientId + "/roles")
+                .then()
+                .statusCode(201);
+    }
+
+    private void createGroupOnKeycloak(final String groupName) {
+        given().header("Authorization", "Bearer " + this.rawAdminToken)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .body(Json.createObjectBuilder()
+                        .add("name", groupName)
+                        .build().toString())
+                .post(this.baseApiUrl.toExternalForm() + "/admin/realms/" + realmName + "/groups")
                 .then()
                 .statusCode(201);
     }
@@ -152,7 +165,7 @@ public class KeycloakConfigurator extends ExternalResource {
         this.adminPassword = builder.adminPassword;
         this.adminUsername = builder.adminUsername;
         try {
-            this.baseApiUrl = new URL("http", builder.keycloakBindAddress, builder.keycloakHttpPort, "/auth");
+            this.baseApiUrl = new URL("http", builder.keycloakBindAddress, builder.keycloakHttpPort, "");
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Malformed URL!", e);
         }

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
@@ -51,17 +51,13 @@ public class KeycloakIntegrationHighLevelScenarioTest {
     private static final String KEYCLOAK_ADMIN_PASSWORD = "password";
 
     public static Docker keycloakContainer = new Docker.Builder(KEYCLOAK_CONTAINER_NAME,
-            "registry.hub.docker.com/jboss/keycloak:8.0.1")
+            "quay.io/keycloak/keycloak:latest")
                     .setContainerReadyTimeout(2, TimeUnit.MINUTES)
                     .setContainerReadyCondition(() -> isContainerReady(KEYCLOAK_EXPOSED_HTTP_PORT))
                     .withPortMapping(KEYCLOAK_EXPOSED_HTTP_PORT + ":8080")
-                    .withPortMapping(KEYCLOAK_EXPOSED_TOKEN_PORT + ":8085")
-                    .withPortMapping(KEYCLOAK_EXPOSED_MANAGEMENT_PORT + ":9990")
-                    .withEnvVar("KEYCLOAK_USER", KEYCLOAK_ADMIN_USERNAME)
-                    .withEnvVar("KEYCLOAK_PASSWORD", KEYCLOAK_ADMIN_PASSWORD)
-                    .withEnvVar("DB_VENDOR", "h2")
-                    .withCmdArg("-b=0.0.0.0")
-                    .withCmdArg("-bmanagement=0.0.0.0")
+                    .withEnvVar("KEYCLOAK_ADMIN", KEYCLOAK_ADMIN_USERNAME)
+                    .withEnvVar("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_ADMIN_PASSWORD)
+                    .withCmdArg("start-dev")
                     .build();
 
     public static KeycloakConfigurator keycloakConfigurator = new KeycloakConfigurator.Builder(KEYCLOAK_REALM_NAME)
@@ -79,9 +75,9 @@ public class KeycloakIntegrationHighLevelScenarioTest {
     @Deployment
     public static Archive<?> createDeployment() {
         //visit http://localhost:8179/auth/realms/foobar/.well-known/openid-configuration with running keycloak for values
-        final String mpProperties = "mp.jwt.verify.publickey.location=http://localhost:8179/auth/realms/%1$s/protocol/openid-connect/certs%n"
+        final String mpProperties = "mp.jwt.verify.publickey.location=http://localhost:8179/realms/%1$s/protocol/openid-connect/certs%n"
                 +
-                "mp.jwt.verify.issuer=http://localhost:8179/auth/realms/%1$s";
+                "mp.jwt.verify.issuer=http://localhost:8179/realms/%1$s";
 
         return ShrinkWrap.create(WebArchive.class, KeycloakIntegrationHighLevelScenarioTest.class.getSimpleName() + ".war")
                 .addClass(SecuredJaxRsEndpoint.class)
@@ -113,7 +109,7 @@ public class KeycloakIntegrationHighLevelScenarioTest {
 
     private static boolean isContainerReady(int port) {
         try {
-            URL url = new URL("http://" + KEYCLOAK_INSTANCE_HOSTNAME + ":" + port + "/auth");
+            URL url = new URL("http://" + KEYCLOAK_INSTANCE_HOSTNAME + ":" + port + "/admin");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
 


### PR DESCRIPTION
This is about updating the Docker tooling configuration for running an updated version of Keycloack from quay, since docker hub often blocks due to pull rate limit.

Due to this the test configuration changes a bit:

* links for keycloak endpoints have been updated
* a group is now created before creating the user, since the latest keycloak version was raising an error when trying to create the user buond to a non-existent group.

Changes have been verified by internal pipeline run, i.e. `microprofile-testsuite` job run 748.

Fixes #264 

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- **N/A** Description of the tests scenarios is included (see #46)