### PR TITLE
Fixing Docker wrapper tests

### DIFF
--- a/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/Docker.java
+++ b/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/Docker.java
@@ -197,19 +197,16 @@ public class Docker extends ExternalResource {
     @Override
     protected void before() throws Throwable {
         System.out.println(
-                Ansi.ansi().reset().a("About to run Docker initialization: ").fgBrightGreen().a(name).reset()
-        );
+                Ansi.ansi().reset().a("About to run Docker initialization: ").fgBrightGreen().a(name).reset());
         start();
         System.out.println(
-                Ansi.ansi().reset().a("Docker initialization was successfully run: ").fgBrightGreen().a(name).reset()
-        );
+                Ansi.ansi().reset().a("Docker initialization was successfully run: ").fgBrightGreen().a(name).reset());
     }
 
     @Override
     protected void after() {
         System.out.println(
-                Ansi.ansi().reset().a("About to run Docker finalization: ").fgBrightGreen().a(name).reset()
-        );
+                Ansi.ansi().reset().a("About to run Docker finalization: ").fgBrightGreen().a(name).reset());
         try {
             stop();
         } catch (Exception e) {
@@ -217,8 +214,7 @@ public class Docker extends ExternalResource {
                     .a(" with ID ").fgYellow().a(uuid).reset());
         }
         System.out.println(
-                Ansi.ansi().reset().a("Docker finalization was successfully run: ").fgBrightGreen().a(name).reset()
-        );
+                Ansi.ansi().reset().a("Docker finalization was successfully run: ").fgBrightGreen().a(name).reset());
     }
 
     public static class Builder {

--- a/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/Docker.java
+++ b/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/Docker.java
@@ -196,17 +196,29 @@ public class Docker extends ExternalResource {
 
     @Override
     protected void before() throws Throwable {
+        System.out.println(
+                Ansi.ansi().reset().a("About to run Docker initialization: ").fgBrightGreen().a(name).reset()
+        );
         start();
+        System.out.println(
+                Ansi.ansi().reset().a("Docker initialization was successfully run: ").fgBrightGreen().a(name).reset()
+        );
     }
 
     @Override
     protected void after() {
+        System.out.println(
+                Ansi.ansi().reset().a("About to run Docker finalization: ").fgBrightGreen().a(name).reset()
+        );
         try {
             stop();
         } catch (Exception e) {
             System.out.println(Ansi.ansi().reset().a("Failed stopping container ").fgCyan().a(name).reset()
                     .a(" with ID ").fgYellow().a(uuid).reset());
         }
+        System.out.println(
+                Ansi.ansi().reset().a("Docker finalization was successfully run: ").fgBrightGreen().a(name).reset()
+        );
     }
 
     public static class Builder {

--- a/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/DockerTest.java
+++ b/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/DockerTest.java
@@ -27,7 +27,7 @@ public class DockerTest {
 
     @ClassRule
     public static Docker wildFlyOne = new Docker.Builder(WILDFLY_ONE_CONTAINER_NAME,
-            "registry.hub.docker.com/jboss/wildfly:18.0.0.Final")
+            "quay.io/wildfly/wildfly")
                     .setContainerReadyTimeout(2, TimeUnit.MINUTES)
                     .setContainerReadyCondition(DockerTest::isWildFlyOneReady)
                     .withPortMapping(WILDFLY_ONE_EXPOSED_HTTP_PORT + ":8080")
@@ -39,7 +39,7 @@ public class DockerTest {
 
     @ClassRule
     public static Docker wildFlyTwo = new Docker.Builder(WILDFLY_TWO_CONTAINER_NAME,
-            "registry.hub.docker.com/jboss/wildfly:18.0.0.Final")
+            "quay.io/wildfly/wildfly")
                     .setContainerReadyTimeout(2, TimeUnit.MINUTES)
                     .setContainerReadyCondition(DockerTest::isWildFlyTwoReady)
                     .withPortMapping(WILDFLY_TWO_EXPOSED_HTTP_PORT + ":8080")

--- a/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/DockerTest.java
+++ b/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/DockerTest.java
@@ -1,8 +1,6 @@
 package org.jboss.eap.qe.ts.common.docker;
 
-import static io.restassured.RestAssured.get;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import java.net.HttpURLConnection;
@@ -10,6 +8,7 @@ import java.net.Socket;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.http.HttpStatus;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -50,20 +49,21 @@ public class DockerTest {
                     .build();
 
     private static boolean isWildFlyOneReady() {
-        return isContainerReady(WILDFLY_ONE_EXPOSED_MANAGEMENT_PORT);
+        return isContainerReady(WILDFLY_ONE_EXPOSED_HTTP_PORT);
     }
 
     private static boolean isWildFlyTwoReady() {
-        return isContainerReady(WILDFLY_TWO_EXPOSED_MANAGEMENT_PORT);
+        return isContainerReady(WILDFLY_TWO_EXPOSED_HTTP_PORT);
     }
 
     private static boolean isContainerReady(int port) {
         try {
-            URL url = new URL("http://" + DEFAULT_SERVER_BIND_ADDRESS + ":" + port + "/health");
+            URL url = new URL("http://" + DEFAULT_SERVER_BIND_ADDRESS + ":" + port);
+
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
 
-            return connection.getResponseMessage().contains("OK");
+            return connection.getResponseCode() == HttpStatus.SC_OK;
         } catch (Exception ex) {
             return false;
         }
@@ -100,29 +100,5 @@ public class DockerTest {
     public void testManagementPortMappingForWildFlyTwo() {
         assertThat(WILDFLY_TWO_CONTAINER_NAME + " container is not listening on port " + WILDFLY_TWO_EXPOSED_MANAGEMENT_PORT,
                 portOpened(WILDFLY_TWO_EXPOSED_MANAGEMENT_PORT), is(true));
-    }
-
-    @Test
-    public void welcomePageAvailableForWildFlyOne() {
-        get("http://" + DEFAULT_SERVER_BIND_ADDRESS + ":" + WILDFLY_ONE_EXPOSED_HTTP_PORT).then()
-                .body(containsString("Welcome to WildFly"));
-    }
-
-    @Test
-    public void welcomePageAvailableForWildFlyTwo() {
-        get("http://" + DEFAULT_SERVER_BIND_ADDRESS + ":" + WILDFLY_TWO_EXPOSED_HTTP_PORT).then()
-                .body(containsString("Welcome to WildFly"));
-    }
-
-    @Test
-    public void healthCheckAvailableForWildFlyOne() {
-        get("http://" + DEFAULT_SERVER_BIND_ADDRESS + ":" + WILDFLY_ONE_EXPOSED_MANAGEMENT_PORT + "/health").then()
-                .body(containsString("UP"));
-    }
-
-    @Test
-    public void healthCheckAvailableForWildFlyTwo() {
-        get("http://" + DEFAULT_SERVER_BIND_ADDRESS + ":" + WILDFLY_TWO_EXPOSED_MANAGEMENT_PORT + "/health").then()
-                .body(containsString("UP"));
     }
 }


### PR DESCRIPTION
Docker wrapper tests are failing because the WIldfly image is still being pushed from docker hub and we reach pull rate limits often there.

Here we replace it with the latest from quay, and we consequently make adjustments to check whether the server is ready, i.e. health checks are no longer used since not part of Widlfly any more by default.

A couple of log messages have been added to trace the docker containers lifecycle start and stop events better.

Verified by internal `microprofile-testsuite` job run 750

Fixes #265 

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)