### PR TITLE
[plugin updates] Maven plugins updated

### DIFF
--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -64,7 +64,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <!-- Package a cloud-server -->
                             <execution>

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -89,7 +89,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <!-- Provision a server with the core functionality we will provide in OpenShift images -->
                             <execution>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -102,7 +102,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <!-- Provision a server with the core functionality we will provide in OpenShift images -->
                             <execution>

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -102,7 +102,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <!-- Provision a server with the core functionality we will provide in OpenShift images -->
                             <execution>

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -109,7 +109,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <!-- Provision a server with the core functionality we will provide in OpenShift images -->
                             <execution>

--- a/microprofile-open-api/pom.xml
+++ b/microprofile-open-api/pom.xml
@@ -82,7 +82,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <!-- Provision a server with the core functionality we will provide in OpenShift images -->
                             <execution>

--- a/microprofile-opentracing/pom.xml
+++ b/microprofile-opentracing/pom.xml
@@ -110,7 +110,6 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-jar-maven-plugin</artifactId>
-                        <version>${version.org.wildfly.jar.plugin}</version>
                         <executions>
                             <!-- Provision a server with the core functionality we will provide in OpenShift images -->
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,25 @@
     </modules>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.min.version>3.5.0</maven.min.version>
+
+        <version.net.revelc.code.formatter-maven-plugin>2.22.0</version.net.revelc.code.formatter-maven-plugin>
+        <version.net.revelc.code.impsort-maven-plugin>1.8.0</version.net.revelc.code.impsort-maven-plugin>
+        <version.org.apache.maven.plugins.maven-antrun-plugin>3.1.0</version.org.apache.maven.plugins.maven-antrun-plugin>
+        <version.org.apache.maven.plugins.maven-dependency-plugin>3.5.0</version.org.apache.maven.plugins.maven-dependency-plugin>
+        <version.org.apache.maven.plugins.maven-enforcer-plugin>3.2.1</version.org.apache.maven.plugins.maven-enforcer-plugin>
+        <version.org.apache.maven.plugins.maven-release-plugin>3.0.0-M7</version.org.apache.maven.plugins.maven-release-plugin>
+        <version.org.apache.maven.plugins.maven-resources-plugin>3.3.0</version.org.apache.maven.plugins.maven-resources-plugin>
+        <version.org.apache.maven.plugins.maven-surefire-plugin>3.0.0-M9</version.org.apache.maven.plugins.maven-surefire-plugin>
+
         <jboss.home>IF-NOT-DEFINED-WILDFLY-WILL-BE-DOWNLOADED-UNZIPPED-AND-USED-AUTOMATICALLY</jboss.home>
         <maven.test.redirectTestOutputToFile>false</maven.test.redirectTestOutputToFile>
         <version.io.rest-assured>5.0.1</version.io.rest-assured>
         <version.jakarta.servlet.jakarta.servlet-api>5.0.0</version.jakarta.servlet.jakarta.servlet-api>
         <version.junit>4.13.1</version.junit>
-        <version.org.apache.maven.plugins.maven-release-plugin>3.0.0-M1</version.org.apache.maven.plugins.maven-release-plugin>
         <version.org.eclipse.microprofile>5.0</version.org.eclipse.microprofile>
         <version.org.jboss.arquillian>1.7.0.Alpha12</version.org.jboss.arquillian>
         <version.org.jboss.wildfly.dist>27.0.0.Alpha4</version.org.jboss.wildfly.dist>
@@ -55,7 +68,6 @@
         <version.org.awaitility>3.1.6</version.org.awaitility>
         <version.org.jboss.shrinkwrap.resolver>3.1.4</version.org.jboss.shrinkwrap.resolver>
         <version.org.postgresql>42.2.8</version.org.postgresql>
-        <version.org.apache.maven.plugins.maven-surefire-plugin>3.0.0-M7</version.org.apache.maven.plugins.maven-surefire-plugin>
         <version.io.opentracing.api>0.31.0</version.io.opentracing.api>
         <version.io.jaegertracing.jaeger-client>1.0.0</version.io.jaegertracing.jaeger-client>
         <container.qualifier.manual.mode>jboss-manual</container.qualifier.manual.mode>
@@ -67,7 +79,7 @@
         <testsuite.galleon.pack.artifactId>wildfly-galleon-pack</testsuite.galleon.pack.artifactId>
         <testsuite.galleon.pack.version>24.0.0.Final</testsuite.galleon.pack.version>
         <!-- Bootable JAR -->
-        <version.org.wildfly.jar.plugin>8.0.0.Alpha3</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>8.1.0.Final</version.org.wildfly.jar.plugin>
         <version.org.bitbucket.b_c.jose4j>0.7.4</version.org.bitbucket.b_c.jose4j>
         <!-- Modular JDK JPMS options -->
         <server.jvm.jpms.args>--add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED</server.jvm.jpms.args>
@@ -300,6 +312,41 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>net.revelc.code.formatter</groupId>
+                    <artifactId>formatter-maven-plugin</artifactId>
+                    <version>${version.net.revelc.code.formatter-maven-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>net.revelc.code</groupId>
+                    <artifactId>impsort-maven-plugin</artifactId>
+                    <version>${version.net.revelc.code.impsort-maven-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>${version.org.apache.maven.plugins.maven-antrun-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${version.org.apache.maven.plugins.maven-dependency-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${version.org.apache.maven.plugins.maven-enforcer-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>${version.org.apache.maven.plugins.maven-release-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${version.org.apache.maven.plugins.maven-resources-plugin}</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
@@ -310,6 +357,11 @@
                         <argLine>${client.jvm.jpms.args}</argLine>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-jar-maven-plugin</artifactId>
+                    <version>${version.org.wildfly.jar.plugin}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -317,7 +369,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>${version.org.apache.maven.plugins.maven-release-plugin}</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <tagNameFormat>@{project.version}</tagNameFormat>
@@ -348,7 +399,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
                 <configuration>
                     <environmentVariables>
                         <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
@@ -497,7 +547,6 @@
                     <plugin>
                         <groupId>net.revelc.code.formatter</groupId>
                         <artifactId>formatter-maven-plugin</artifactId>
-                        <version>2.11.0</version>
                         <configuration>
                             <configFile>${maven.multiModuleProjectDirectory}/ide-config/eclipse-format.xml</configFile>
                         </configuration>
@@ -513,9 +562,8 @@
                     <plugin>
                         <groupId>net.revelc.code</groupId>
                         <artifactId>impsort-maven-plugin</artifactId>
-                        <version>1.3.2</version>
                         <configuration>
-                            <groups>java.,javax.,org.,com.</groups>
+                            <groups>java.,javax.,jakarta.,org.,com.</groups>
                             <staticGroups>*</staticGroups>
                             <removeUnused>true</removeUnused>
                         </configuration>


### PR DESCRIPTION
- Almost all maven plugins are updated with this commit.
- Maven enforcer for minimum maven version added
- Main reason for this is update of the `net.revelc.code:impsort-maven-plugin` because of the issue [1] on Maven 3.9.0:

```
[ERROR] Failed to execute goal net.revelc.code:impsort-maven-plugin:1.6.2:sort (sort-imports)
 on project appsint-deployments-provider: Execution sort-imports of goal
 net.revelc.code:impsort-maven-plugin:1.6.2:sort failed: A required class was missing while
 executing net.revelc.code:impsort-maven-plugin:1.6.2:sort: org/codehaus/plexus/util/DirectoryScanner
```

[1] https://github.com/revelc/impsort-maven-plugin/issues/64



Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)