### PR TITLE
[issue-282] - Fixing "Provider org.eclipse.parsson.JsonProviderImpl not found"

### DIFF
--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -44,6 +44,12 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.eap.qe</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <!-- Bootable JAR -->
         <version.org.wildfly.jar.plugin>11.0.0.Beta1</version.org.wildfly.jar.plugin>
         <version.org.bitbucket.b_c.jose4j>0.7.4</version.org.bitbucket.b_c.jose4j>
+        <version.org.eclipse.parsson>1.1.5</version.org.eclipse.parsson>
 
         <!-- XP Channel manifest GAV -->
         <channel-manifest.groupId>org.jboss.eap.channels</channel-manifest.groupId>
@@ -211,6 +212,12 @@
                 <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.json</artifactId>
                 <version>${version.org.glassfish.jakarta.json}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.parsson</groupId>
+                <artifactId>parsson</artifactId>
+                <version>${version.org.eclipse.parsson}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/tooling-mp-jwt-auth-tool/pom.xml
+++ b/tooling-mp-jwt-auth-tool/pom.xml
@@ -22,9 +22,15 @@
             <artifactId>jose4j</artifactId>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Fixing "Provider org.eclipse.parsson.JsonProviderImpl not found" by providing the actual implementation that was previously pulled in transitively.

See motivation for changes in issue discussion: https://github.com/jboss-eap-qe/eap-microprofile-test-suite/issues/282#issuecomment-2011040769

Fix #282 

CI runs:
* Wildfly: eap-8.x-microprofile-simple-face run: 97
* EAP XP: eap-8.x-microprofile-simple-face run: 96

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [ ] **N/A** Description of the tests scenarios is included (see #46)