### PR TITLE
Fix KeycloakIntegrationHighLevelScenarioTest

### DIFF
--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakConfigurator.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakConfigurator.java
@@ -34,7 +34,7 @@ public class KeycloakConfigurator extends ExternalResource {
     private String rawAdminToken;
 
     @Override
-    public void before() {
+    public void before() throws InterruptedException {
         rawAdminToken = authorizeAndObtainRawJwtForAdminInterface(adminUsername, adminPassword);
         createRealmOnKeycloak(this.realmName);
         createClientOnKeycloak(this.realmName, this.clientId);

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakConfigurator.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakConfigurator.java
@@ -68,6 +68,18 @@ public class KeycloakConfigurator extends ExternalResource {
                 .post(this.baseApiUrl + "/admin/realms")
                 .then()
                 .statusCode(201);
+
+        // From Keycloak 24 on, VerifyProfile action is enabled by default for new users in the realm, and it may require users
+        // to update profile on the first login, which we don't need for tests.
+        // https://www.keycloak.org/docs/latest/upgrading/index.html#verify-profile-required-action-enabled-by-default
+        // Let's disable (by simply deleting it) it as upstream is disabling it in tests too
+        // https://github.com/keycloak/keycloak/pull/26561/files#diff-dbb790e97fd89883d9bb2731bfeadf8276d937fda21a474d2df08bddfd39c654R518-R529
+        given().header("Authorization", "Bearer " + this.rawAdminToken)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .delete(this.baseApiUrl + "/admin/realms/" + realmName + "/authentication/required-actions/VERIFY_PROFILE")
+                .then()
+                .statusCode(204);
     }
 
     private void createClientOnKeycloak(final String realmName, final String clientId) {

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
@@ -57,6 +57,7 @@ public class KeycloakIntegrationHighLevelScenarioTest {
             .withPortMapping(KEYCLOAK_EXPOSED_HTTP_PORT + ":8080")
             .withEnvVar("KEYCLOAK_ADMIN", KEYCLOAK_ADMIN_USERNAME)
             .withEnvVar("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_ADMIN_PASSWORD)
+            .withEnvVar("KC_HEALTH_ENABLED", "true")
             .withCmdArg("start-dev")
             .withCmdArg("--log-level=DEBUG")
             .build();
@@ -110,7 +111,7 @@ public class KeycloakIntegrationHighLevelScenarioTest {
 
     private static boolean isContainerReady(int port) {
         try {
-            URL url = new URL("http://" + KEYCLOAK_INSTANCE_HOSTNAME + ":" + port + "/admin");
+            URL url = new URL("http://" + KEYCLOAK_INSTANCE_HOSTNAME + ":" + port + "/health/ready");
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
 

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
@@ -98,7 +98,7 @@ public class KeycloakIntegrationHighLevelScenarioTest {
         final String username = "qux";
         final String password = "foo";
         keycloakConfigurator.addUser(username, password);
-        final String rawToken = keycloakConfigurator.getRawJwtFromKeyCloak(username, password);
+        final String rawToken = keycloakConfigurator.getRawJwtFromKeyCloakForTestUser(username, password);
 
         given().header("Authorization", "Bearer " + rawToken)
                 .when().get(url.toExternalForm() + Endpoints.SECURED_ENDPOINT)

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
@@ -58,6 +58,7 @@ public class KeycloakIntegrationHighLevelScenarioTest {
             .withEnvVar("KEYCLOAK_ADMIN", KEYCLOAK_ADMIN_USERNAME)
             .withEnvVar("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_ADMIN_PASSWORD)
             .withCmdArg("start-dev")
+            .withCmdArg("--log-level=DEBUG")
             .build();
 
     public static KeycloakConfigurator keycloakConfigurator = new KeycloakConfigurator.Builder(KEYCLOAK_REALM_NAME)

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
@@ -115,7 +115,12 @@ public class KeycloakIntegrationHighLevelScenarioTest {
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
 
-            return connection.getResponseCode() == HttpURLConnection.HTTP_OK;
+            boolean ready = connection.getResponseCode() == HttpURLConnection.HTTP_OK;
+            if (ready) {
+                System.out.println("Let's wait addional 10 seconds before the post-start tasks (like creation of admin user) on container are done.");
+                Thread.sleep(10000L);
+            }
+            return ready;
         } catch (Exception ex) {
             return false;
         }


### PR DESCRIPTION
There were two major issues with this test:

1) with update to Keycloak 24, there is a new default required action attached to each new user - Verify Profile - that prevents from getting token unless additional action is performed on first login.
We are removing this new check, as we don't need it for tests.

2) there was a race condition when docker container was started and tests started to execute while the initial admin user still wasn't created. It turned out, readiness probe at /health/ready isn't enough to say if we are fully booted for tests, so we need some additional time for perform post-boot tasks before we continue with tests.

CI run at eap-8.x-microprofile-testsuite/861