### PR TITLE
[MP OpenAPI] - Fix the Bootable JAR plugin config in order to add the microprofile-rest-client layer

### DIFF
--- a/microprofile-open-api/pom.xml
+++ b/microprofile-open-api/pom.xml
@@ -109,6 +109,13 @@
                                         <layer>cloud-server</layer>
                                         <layer>undertow-https</layer>
                                         <layer>microprofile-openapi</layer>
+                                        <!--
+                                            We're testing integration with MP REST Client too, and the layer must be
+                                            added explicitly, see https://issues.redhat.com/browse/JBEAP-26776
+                                            ... at least for XP 5, we'll see whether this will be applied to WildFly as
+                                            well
+                                        -->
+                                        <layer>microprofile-rest-client</layer>
                                     </layers>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
Following up on https://issues.redhat.com/browse/JBEAP-26776, this is adding the microprofile-rest-client layer  to the Bootable JAR plugin configuration for the `microprofile-open-api` module.

This seems to be the valid configuration ATM, so we need align it to the EAP XP 5 feature pack definition.

Internal **CI run** reference: 
- **job**: eap-8.x-microprofile-simple-face
- **run**: 103 

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- **N/A** Description of the tests scenarios is included (see #46)