### PR TITLE
[MP Fault Tolerance] - Fixing the PostrgreSql image TAG since latest is no longer valid

### DIFF
--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/DatabaseCrashTest.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/DatabaseCrashTest.java
@@ -92,7 +92,7 @@ public class DatabaseCrashTest {
         // create data dir for postgres database
         postgresDataDir = Files.createTempDir();
         // https://github.com/sclorg/postgresql-container/tree/generated/13
-        postgresDB = new Docker.Builder("postgres", "quay.io/centos7/postgresql-13-centos7")
+        postgresDB = new Docker.Builder("postgres", "quay.io/centos7/postgresql-13-centos7:centos7")
                 .setContainerReadyCondition(() -> {
                     // checking port 5432 is not an option as PostgreSQL opens it before it's ready when started for the 1st time
                     // thus try to create JDBC connection directly


### PR DESCRIPTION
The used image/tag is no longer supported, see https://quay.io/repository/centos7/postgresql-13-centos7, so a quick fix is to use the `:centos7`, while the actual solution would be to upgrade the supported PostgreSql image version, e.g.: https://quay.io/repository/sclorg/postgresql-15-c9s?tab=info

Internal **CI run** reference: 
- **job**: eap-8.x-microprofile-simple-face
- **run**: 104 

**N.B.**: failures in microprofile-open-api are expected and fixed by #285 

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided
- **N/A** Code is self-descriptive and/or documented
- **N/A** Description of the tests scenarios is included (see #46)