### PR TITLE
[issue 292](xp5) - Fix Postgresql data directory permissions to work on RHEL 9 Docker hosts

### DIFF
--- a/micrometer/src/test/java/org/jboss/eap/qe/micrometer/MicrometerOtelIntegrationTestCase.java
+++ b/micrometer/src/test/java/org/jboss/eap/qe/micrometer/MicrometerOtelIntegrationTestCase.java
@@ -34,11 +34,10 @@ import org.junit.runner.RunWith;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 
-
 /**
  * Tests that metrics can be pushed to the OpenTelemetry collector by Micrometer, and then exported to Jaeger.
  * This class is based on the similar one in WildFly, although it uses a different {@code @ServerSetup} task class,
- * i.e. {@link  MicrometerServerSetup}, which provides the logic for executing the required configuration
+ * i.e. {@link MicrometerServerSetup}, which provides the logic for executing the required configuration
  * (see {@link org.jboss.eap.qe.micrometer.util.MicrometerServerConfiguration}) within the Arquillian container.
  */
 @RunWith(Arquillian.class)
@@ -132,7 +131,6 @@ public class MicrometerOtelIntegrationTestCase {
         metricsToTest.forEach(n -> Assert.assertTrue("Missing metric: " + n,
                 metrics.stream().anyMatch(m -> m.getKey().startsWith(n))));
     }
-
 
     /**
      * Request the published metrics from the OpenTelemetry Collector via the configured Prometheus exporter and check


### PR DESCRIPTION
Backporting changes in https://github.com/jboss-eap-qe/eap-microprofile-test-suite/pull/291 to the `xp5` branch

**Reference to internal validation job run**:
- job: eap-80x-microprofile-simple-face 
- run: 5

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] ~Link~ Reference to the passing job is provided
- [x] Code is self-descriptive and/or documented
- **N/A** Description of the tests scenarios is included (see #46)