### PR TITLE
Fix some tests failures on Windows

### DIFF
--- a/micrometer/pom.xml
+++ b/micrometer/pom.xml
@@ -61,4 +61,81 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <!-- Test against Bootable JAR -->
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                                <configuration>
+                                    <systemPropertyVariables combine.children="append">
+                                        <jboss.args/>
+                                        <install.dir>${project.build.directory}/jboss-as-bootable</install.dir>
+                                        <bootable.jar>${project.build.directory}/test-micrometer-bootable.jar</bootable.jar>
+                                        <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                                    </systemPropertyVariables>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>
+                                            org.wildfly.arquillian:wildfly-arquillian-container-managed
+                                        </classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Bootable JAR Maven plugin -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <executions>
+                            <!-- Provision a server with the core functionality we will provide in OpenShift images -->
+                            <execution>
+                                <id>bootable-jar-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <output-file-name>test-micrometer-bootable.jar</output-file-name>
+                                    <hollowJar>true</hollowJar>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <plugin-options>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.galleon.pack.version}</version>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>micrometer</layer>
+                                    </layers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/micrometer/src/test/java/org/jboss/eap/qe/micrometer/MicrometerOtelIntegrationTestCase.java
+++ b/micrometer/src/test/java/org/jboss/eap/qe/micrometer/MicrometerOtelIntegrationTestCase.java
@@ -22,6 +22,7 @@ import org.jboss.eap.qe.micrometer.container.PrometheusMetric;
 import org.jboss.eap.qe.micrometer.util.MicrometerServerSetup;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.deployment.ConfigurationUtil;
 import org.jboss.eap.qe.ts.common.docker.Docker;
+import org.jboss.eap.qe.ts.common.docker.junit.DockerRequiredTests;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -29,6 +30,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import io.micrometer.core.instrument.Counter;
@@ -42,6 +44,7 @@ import io.micrometer.core.instrument.MeterRegistry;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(MicrometerServerSetup.class) // Enables/Disables Micrometer extension/subsystem for Arquillian in-container tests
+@Category(DockerRequiredTests.class)
 public class MicrometerOtelIntegrationTestCase {
     public static final int REQUEST_COUNT = 5;
     @ArquillianResource

--- a/micrometer/src/test/java/org/jboss/eap/qe/micrometer/MicrometerOtelIntegrationTestCase.java
+++ b/micrometer/src/test/java/org/jboss/eap/qe/micrometer/MicrometerOtelIntegrationTestCase.java
@@ -63,7 +63,7 @@ public class MicrometerOtelIntegrationTestCase {
             + "    </servlet-mapping>"
             + "</web-app>\n";
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, "micrometer-test.war")
                 .addClasses(

--- a/micrometer/src/test/java/org/jboss/eap/qe/micrometer/MicrometerOtelIntegrationTestCase.java
+++ b/micrometer/src/test/java/org/jboss/eap/qe/micrometer/MicrometerOtelIntegrationTestCase.java
@@ -63,7 +63,7 @@ public class MicrometerOtelIntegrationTestCase {
             + "    </servlet-mapping>"
             + "</web-app>\n";
 
-    @Deployment(testable = false)
+    @Deployment
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, "micrometer-test.war")
                 .addClasses(

--- a/micrometer/src/test/java/org/jboss/eap/qe/micrometer/multiple/EarDeploymentTestCase.java
+++ b/micrometer/src/test/java/org/jboss/eap/qe/micrometer/multiple/EarDeploymentTestCase.java
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith;
 public class EarDeploymentTestCase extends BaseMultipleTestCase {
     protected static final String ENTERPRISE_APP = "enterprise-app";
 
-    @Deployment(name = ENTERPRISE_APP)
+    @Deployment(name = ENTERPRISE_APP, testable = false)
     public static EnterpriseArchive createDeployment() {
         return ShrinkWrap.create(EnterpriseArchive.class, ENTERPRISE_APP + ".ear")
                 .addAsModules(MultipleWarTestCase.createDeployment1(),

--- a/micrometer/src/test/java/org/jboss/eap/qe/micrometer/multiple/EarDeploymentTestCase.java
+++ b/micrometer/src/test/java/org/jboss/eap/qe/micrometer/multiple/EarDeploymentTestCase.java
@@ -19,15 +19,18 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.micrometer.container.OpenTelemetryCollectorContainer;
 import org.jboss.eap.qe.micrometer.container.PrometheusMetric;
 import org.jboss.eap.qe.micrometer.util.MicrometerServerSetup;
+import org.jboss.eap.qe.ts.common.docker.junit.DockerRequiredTests;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 @ServerSetup(MicrometerServerSetup.class)
+@Category(DockerRequiredTests.class)
 public class EarDeploymentTestCase extends BaseMultipleTestCase {
     protected static final String ENTERPRISE_APP = "enterprise-app";
 

--- a/micrometer/src/test/java/org/jboss/eap/qe/micrometer/multiple/MultipleWarTestCase.java
+++ b/micrometer/src/test/java/org/jboss/eap/qe/micrometer/multiple/MultipleWarTestCase.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 @ServerSetup(MicrometerServerSetup.class)
 @Category(DockerRequiredTests.class)
 public class MultipleWarTestCase extends BaseMultipleTestCase {
-    @Deployment(name = SERVICE_ONE, order = 1)
+    @Deployment(name = SERVICE_ONE, order = 1, testable = false)
     public static WebArchive createDeployment1() {
         return ShrinkWrap.create(WebArchive.class, SERVICE_ONE + ".war")
                 .addClasses(TestApplication.class, DuplicateMetricResource1.class, BaseMultipleTestCase.class)
@@ -40,7 +40,7 @@ public class MultipleWarTestCase extends BaseMultipleTestCase {
 
     }
 
-    @Deployment(name = SERVICE_TWO, order = 2)
+    @Deployment(name = SERVICE_TWO, order = 2, testable = false)
     public static WebArchive createDeployment2() {
         return ShrinkWrap.create(WebArchive.class, SERVICE_TWO + ".war")
                 .addClasses(TestApplication.class, DuplicateMetricResource2.class, BaseMultipleTestCase.class)

--- a/micrometer/src/test/java/org/jboss/eap/qe/micrometer/multiple/MultipleWarTestCase.java
+++ b/micrometer/src/test/java/org/jboss/eap/qe/micrometer/multiple/MultipleWarTestCase.java
@@ -20,14 +20,17 @@ import org.jboss.eap.qe.micrometer.container.OpenTelemetryCollectorContainer;
 import org.jboss.eap.qe.micrometer.container.PrometheusMetric;
 import org.jboss.eap.qe.micrometer.util.MicrometerServerSetup;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.deployment.ConfigurationUtil;
+import org.jboss.eap.qe.ts.common.docker.junit.DockerRequiredTests;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 @ServerSetup(MicrometerServerSetup.class)
+@Category(DockerRequiredTests.class)
 public class MultipleWarTestCase extends BaseMultipleTestCase {
     @Deployment(name = SERVICE_ONE, order = 1)
     public static WebArchive createDeployment1() {

--- a/micrometer/src/test/resources/arquillian-bootable.xml
+++ b/micrometer/src/test/resources/arquillian-bootable.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="Servlet 5.0"/>
+
+    <group qualifier="container-group" default="true">
+        <container qualifier="jboss" default="true">
+            <configuration>
+                <property name="installDir">${install.dir}</property>
+                <property name="jarFile">${bootable.jar}</property>
+                <property name="javaVmArguments">${server.jvm.args}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">127.0.0.1</property>
+                <property name="managementPort">9990</property>
+            </configuration>
+        </container>
+    </group>
+</arquillian>

--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/DatabaseCrashTest.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/DatabaseCrashTest.java
@@ -25,6 +25,7 @@ import org.jboss.eap.qe.microprofile.fault.tolerance.deployments.database.Databa
 import org.jboss.eap.qe.microprofile.fault.tolerance.util.MicroProfileFaultToleranceServerConfiguration;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.deployment.ConfigurationUtil;
 import org.jboss.eap.qe.ts.common.docker.Docker;
+import org.jboss.eap.qe.ts.common.docker.junit.DockerRequiredTests;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -35,6 +36,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import com.google.common.io.Files;
@@ -44,6 +46,7 @@ import com.google.common.io.Files;
  */
 @RunAsClient
 @RunWith(Arquillian.class)
+@Category(DockerRequiredTests.class)
 public class DatabaseCrashTest {
 
     private static final String APPLICATION_NAME = "DatabaseServlet";

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -88,12 +88,6 @@
                                             org.wildfly.arquillian:wildfly-arquillian-container-managed
                                         </classpathDependencyExclude>
                                     </classpathDependencyExcludes>
-                                    <excludes>
-                                        <!-- Need MP FaultTolerance -->
-                                        <exclude>org/jboss/eap/qe/microprofile/health/integration/FailSafe*Test.java</exclude>
-                                        <!-- Needs manual container -->
-                                        <exclude>org/jboss/eap/qe/microprofile/health/delay/*Test.java</exclude>
-                                    </excludes>
                                 </configuration>
                             </execution>
                         </executions>

--- a/microprofile-health/src/main/java/org/jboss/eap/qe/microprofile/health/junit/HealthWithFaultToleranceTests.java
+++ b/microprofile-health/src/main/java/org/jboss/eap/qe/microprofile/health/junit/HealthWithFaultToleranceTests.java
@@ -1,0 +1,8 @@
+package org.jboss.eap.qe.microprofile.health.junit;
+
+/**
+ * An interface that marks a test class which uses MicroProfile Health + Fault Tolerance integration.
+ * Used via JUnit {@code org.junit.experimental.categories.Category} to include or exclude groups of tests.
+ */
+public interface HealthWithFaultToleranceTests {
+}

--- a/microprofile-health/src/main/java/org/jboss/eap/qe/microprofile/health/junit/ManualTests.java
+++ b/microprofile-health/src/main/java/org/jboss/eap/qe/microprofile/health/junit/ManualTests.java
@@ -1,0 +1,9 @@
+package org.jboss.eap.qe.microprofile.health.junit;
+
+/**
+ * An interface that marks a test class which handles the Arquillian life cycle manually.
+ * Used via JUnit {@code org.junit.experimental.categories.Category} to include or exclude groups of tests.
+ */
+public interface ManualTests {
+    String ARQUILLIAN_CONTAINER = "jboss-manual";
+}

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/ManualTests.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/ManualTests.java
@@ -1,5 +1,0 @@
-package org.jboss.eap.qe.microprofile.health;
-
-public interface ManualTests {
-    String ARQUILLIAN_CONTAINER = "jboss-manual";
-}

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/delay/NotReadyHealthCheckTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/delay/NotReadyHealthCheckTest.java
@@ -20,7 +20,7 @@ import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.eap.qe.microprofile.health.ManualTests;
+import org.jboss.eap.qe.microprofile.health.junit.ManualTests;
 import org.jboss.eap.qe.microprofile.health.tools.HealthUrlProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIConfigFileHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIConfigFileHealthTest.java
@@ -18,6 +18,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.DisableDefaultHealthProceduresSetupTask;
+import org.jboss.eap.qe.microprofile.health.junit.HealthWithFaultToleranceTests;
 import org.jboss.eap.qe.microprofile.health.tools.HealthUrlProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
@@ -30,6 +31,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
@@ -58,6 +60,7 @@ import io.restassured.specification.RequestSpecification;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ DisableDefaultHealthProceduresSetupTask.class })
+@Category(HealthWithFaultToleranceTests.class)
 public class FailSafeCDIConfigFileHealthTest {
 
     private static final String MPConfigContent = String.format("%s=%s\n%s=%s\n%s=%s\n%s=%s",

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDICustomConfigSourceHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDICustomConfigSourceHealthTest.java
@@ -11,11 +11,13 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.DisableDefaultHealthProceduresSetupTask;
+import org.jboss.eap.qe.microprofile.health.junit.HealthWithFaultToleranceTests;
 import org.jboss.eap.qe.microprofile.tooling.server.ModuleUtil;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 
@@ -27,6 +29,7 @@ import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ DisableDefaultHealthProceduresSetupTask.class, FailSafeCDICustomConfigSourceHealthTest.SetupTask.class })
+@Category(HealthWithFaultToleranceTests.class)
 public class FailSafeCDICustomConfigSourceHealthTest extends FailSafeCDIHealthDynamicBaseTest {
     private static final String PROPERTY_FILENAME = "health.properties";
     Path propertyFile = Paths.get(FailSafeCDICustomConfigSourceHealthTest.class.getResource(PROPERTY_FILENAME).toURI());

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDICustomConfigSourceHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDICustomConfigSourceHealthTest.java
@@ -1,6 +1,7 @@
 package org.jboss.eap.qe.microprofile.health.integration;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -28,8 +29,11 @@ import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 @ServerSetup({ DisableDefaultHealthProceduresSetupTask.class, FailSafeCDICustomConfigSourceHealthTest.SetupTask.class })
 public class FailSafeCDICustomConfigSourceHealthTest extends FailSafeCDIHealthDynamicBaseTest {
     private static final String PROPERTY_FILENAME = "health.properties";
-    Path propertyFile = Paths.get(FailSafeCDICustomConfigSourceHealthTest.class.getResource(PROPERTY_FILENAME).getPath());
+    Path propertyFile = Paths.get(FailSafeCDICustomConfigSourceHealthTest.class.getResource(PROPERTY_FILENAME).toURI());
     private byte[] bytes;
+
+    public FailSafeCDICustomConfigSourceHealthTest() throws URISyntaxException {
+    }
 
     @Before
     public void backup() throws IOException {
@@ -65,7 +69,7 @@ public class FailSafeCDICustomConfigSourceHealthTest extends FailSafeCDIHealthDy
                 client.execute(String.format("/system-property=%s:add(value=%s)", CustomConfigSource.PROPERTIES_FILE_PATH,
                         SetupTask.class.getResource(PROPERTY_FILENAME).getFile())).assertSuccess();
                 ModuleUtil.add(TEST_MODULE_NAME)
-                        .setModuleXMLPath(SetupTask.class.getResource("configSourceModule.xml").getPath())
+                        .setModuleXMLPath(SetupTask.class.getResource("configSourceModule.xml").toURI().getPath())
                         .addResource("config-source", CustomConfigSource.class)
                         .executeOn(client);
                 client.execute(String.format(

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDICustomConfigSourceProviderHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDICustomConfigSourceProviderHealthTest.java
@@ -11,11 +11,13 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.DisableDefaultHealthProceduresSetupTask;
+import org.jboss.eap.qe.microprofile.health.junit.HealthWithFaultToleranceTests;
 import org.jboss.eap.qe.microprofile.tooling.server.ModuleUtil;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 
@@ -27,6 +29,7 @@ import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ DisableDefaultHealthProceduresSetupTask.class, FailSafeCDICustomConfigSourceProviderHealthTest.SetupTask.class })
+@Category(HealthWithFaultToleranceTests.class)
 public class FailSafeCDICustomConfigSourceProviderHealthTest extends FailSafeCDIHealthDynamicBaseTest {
     private static final String PROPERTY_FILENAME = "health.properties";
     Path propertyFile = Paths.get(

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDICustomConfigSourceProviderHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDICustomConfigSourceProviderHealthTest.java
@@ -1,6 +1,7 @@
 package org.jboss.eap.qe.microprofile.health.integration;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,8 +30,11 @@ import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 public class FailSafeCDICustomConfigSourceProviderHealthTest extends FailSafeCDIHealthDynamicBaseTest {
     private static final String PROPERTY_FILENAME = "health.properties";
     Path propertyFile = Paths.get(
-            FailSafeCDICustomConfigSourceProviderHealthTest.class.getResource(PROPERTY_FILENAME).getPath());
+            FailSafeCDICustomConfigSourceProviderHealthTest.class.getResource(PROPERTY_FILENAME).toURI());
     private byte[] bytes;
+
+    public FailSafeCDICustomConfigSourceProviderHealthTest() throws URISyntaxException {
+    }
 
     @Before
     public void backup() throws IOException {
@@ -68,7 +72,7 @@ public class FailSafeCDICustomConfigSourceProviderHealthTest extends FailSafeCDI
                         CustomConfigSource.PROPERTIES_FILE_PATH, SetupTask.class.getResource(PROPERTY_FILENAME).getFile()))
                         .assertSuccess();
                 ModuleUtil.add(TEST_MODULE_NAME)
-                        .setModuleXMLPath(SetupTask.class.getResource("configSourceProviderModule.xml").getPath())
+                        .setModuleXMLPath(SetupTask.class.getResource("configSourceProviderModule.xml").toURI().getPath())
                         .addResource("config-source-provider", CustomConfigSource.class, CustomConfigSourceProvider.class)
                         .executeOn(client);
                 client.execute(String.format(

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIHealthDynamicBaseTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIHealthDynamicBaseTest.java
@@ -13,8 +13,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.eap.qe.microprofile.health.junit.HealthWithFaultToleranceTests;
 import org.jboss.eap.qe.microprofile.health.tools.HealthUrlProvider;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import io.restassured.http.ContentType;
 
@@ -25,6 +27,7 @@ import io.restassured.http.ContentType;
  * Test class extends {@link FailSafeCDIHealthBaseTest} for those scenarios that expect dynamic MP Config.
  */
 @RunAsClient
+@Category(HealthWithFaultToleranceTests.class)
 public abstract class FailSafeCDIHealthDynamicBaseTest extends FailSafeCDIHealthBaseTest {
 
     /**

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIModelFilePropsHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIModelFilePropsHealthTest.java
@@ -11,10 +11,12 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.DisableDefaultHealthProceduresSetupTask;
+import org.jboss.eap.qe.microprofile.health.junit.HealthWithFaultToleranceTests;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
@@ -28,6 +30,7 @@ import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ DisableDefaultHealthProceduresSetupTask.class, FailSafeCDIModelFilePropsHealthTest.SetupTask.class })
+@Category(HealthWithFaultToleranceTests.class)
 public class FailSafeCDIModelFilePropsHealthTest extends FailSafeCDIHealthBaseTest {
 
     private byte[] liveFileBytes;

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIModelFilePropsHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIModelFilePropsHealthTest.java
@@ -1,6 +1,7 @@
 package org.jboss.eap.qe.microprofile.health.integration;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -36,19 +37,22 @@ public class FailSafeCDIModelFilePropsHealthTest extends FailSafeCDIHealthBaseTe
 
     Path liveFile = Paths.get(
             FailSafeCDIModelFilePropsHealthTest.class.getResource("file-props/" + FailSafeDummyService.LIVE_CONFIG_PROPERTY)
-                    .getPath());
+                    .toURI());
 
     Path readyFile = Paths.get(
             FailSafeCDIModelFilePropsHealthTest.class.getResource("file-props/" + FailSafeDummyService.READY_CONFIG_PROPERTY)
-                    .getFile());
+                    .toURI());
 
     Path inMaintenanceFile = Paths.get(
             FailSafeCDIModelFilePropsHealthTest.class
-                    .getResource("file-props/" + FailSafeDummyService.IN_MAINTENANCE_CONFIG_PROPERTY).getPath());
+                    .getResource("file-props/" + FailSafeDummyService.IN_MAINTENANCE_CONFIG_PROPERTY).toURI());
 
     Path readyInMaintenanceFile = Paths.get(
             FailSafeCDIModelFilePropsHealthTest.class
-                    .getResource("file-props/" + FailSafeDummyService.READY_IN_MAINTENANCE_CONFIG_PROPERTY).getPath());
+                    .getResource("file-props/" + FailSafeDummyService.READY_IN_MAINTENANCE_CONFIG_PROPERTY).toURI());
+
+    public FailSafeCDIModelFilePropsHealthTest() throws URISyntaxException {
+    }
 
     @Before
     public void backup() throws IOException {

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIModelPropsHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDIModelPropsHealthTest.java
@@ -4,8 +4,10 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.DisableDefaultHealthProceduresSetupTask;
+import org.jboss.eap.qe.microprofile.health.junit.HealthWithFaultToleranceTests;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
@@ -18,6 +20,7 @@ import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ DisableDefaultHealthProceduresSetupTask.class, FailSafeCDIModelPropsHealthTest.SetupTask.class })
+@Category(HealthWithFaultToleranceTests.class)
 public class FailSafeCDIModelPropsHealthTest extends FailSafeCDIHealthBaseTest {
 
     @Override

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDISystemPropertyHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/integration/FailSafeCDISystemPropertyHealthTest.java
@@ -4,8 +4,10 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.DisableDefaultHealthProceduresSetupTask;
+import org.jboss.eap.qe.microprofile.health.junit.HealthWithFaultToleranceTests;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.MicroProfileServerSetupTask;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
@@ -18,6 +20,7 @@ import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ DisableDefaultHealthProceduresSetupTask.class, FailSafeCDISystemPropertyHealthTest.SetupTask.class })
+@Category(HealthWithFaultToleranceTests.class)
 public class FailSafeCDISystemPropertyHealthTest extends FailSafeCDIHealthBaseTest {
 
     @Override

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
@@ -17,12 +17,14 @@ import org.jboss.eap.qe.microprofile.jwt.testapp.Endpoints;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.JaxRsTestApplication;
 import org.jboss.eap.qe.microprofile.jwt.testapp.jaxrs.SecuredJaxRsEndpoint;
 import org.jboss.eap.qe.ts.common.docker.Docker;
+import org.jboss.eap.qe.ts.common.docker.junit.DockerRequiredTests;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
@@ -34,6 +36,7 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(EnableJwtSubsystemSetupTask.class)
+@Category(DockerRequiredTests.class)
 public class KeycloakIntegrationHighLevelScenarioTest {
 
     private static final String KEYCLOAK_REALM_NAME = "foobar";

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/security/ListenerSecurityConfigurationTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/security/ListenerSecurityConfigurationTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.not;
 
 import jakarta.ws.rs.core.MediaType;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -103,9 +104,9 @@ public class ListenerSecurityConfigurationTest {
         @Override
         public void setup() throws Exception {
             if (Boolean.getBoolean("ts.bootable")) {
-                jbossHome = arquillianContainerProperties.getContainerProperty("jboss", "installDir");
+                jbossHome = arquillianContainerProperties.getContainerProperty("jboss", "installDir").replace("\\", "/");
             } else {
-                jbossHome = arquillianContainerProperties.getContainerProperty("jboss", "jbossHome");
+                jbossHome = arquillianContainerProperties.getContainerProperty("jboss", "jbossHome").replace("\\", "/");
             }
             try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
                 //  configured server ports for HTTP and HTTPS bindings, offset is taken into account

--- a/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/security/ListenerSecurityConfigurationTest.java
+++ b/microprofile-open-api/src/test/java/org/jboss/eap/qe/microprofile/openapi/security/ListenerSecurityConfigurationTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.Matchers.not;
 
 import jakarta.ws.rs.core.MediaType;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,9 @@
         <!-- Modular JDK JPMS options -->
         <server.jvm.jpms.args>--add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED</server.jvm.jpms.args>
         <client.jvm.jpms.args>--add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED</client.jvm.jpms.args>
+
+        <!-- Using JUnit @Category to dynamically select executed test groups, based on multiple factors (e.g.: regular vs. bootable and Linux vs. Windows executions -->
+        <current-execution.excluded-groups></current-execution.excluded-groups>
     </properties>
 
     <dependencyManagement>
@@ -432,6 +435,7 @@
                         <module.path>${jboss.modules.path}</module.path>
                         <arquillian.xml>${maven.multiModuleProjectDirectory}/arquillian.xml</arquillian.xml>
                     </systemPropertyVariables>
+                    <excludedGroups>${current-execution.excluded-groups}</excludedGroups>
                 </configuration>
             </plugin>
         </plugins>
@@ -643,15 +647,6 @@
                                 <phase>none</phase>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/micrometer/**</exclude>
-                            </excludes>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/junit/DockerRequiredTests.java
+++ b/tooling-docker/src/main/java/org/jboss/eap/qe/ts/common/docker/junit/DockerRequiredTests.java
@@ -1,0 +1,8 @@
+package org.jboss.eap.qe.ts.common.docker.junit;
+
+/**
+ * An interface that marks a test class which requires a docker service running locally.
+ * Used via JUnit {@code org.junit.experimental.categories.Category} to include or exclude groups of tests.
+ */
+public interface DockerRequiredTests {
+}

--- a/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/DockerTest.java
+++ b/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/DockerTest.java
@@ -9,9 +9,12 @@ import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpStatus;
+import org.jboss.eap.qe.ts.common.docker.junit.DockerRequiredTests;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(DockerRequiredTests.class)
 public class DockerTest {
 
     private static final String DEFAULT_SERVER_BIND_ADDRESS = "127.0.0.1";

--- a/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/MalformedDockerConfigTest.java
+++ b/tooling-docker/src/test/java/org/jboss/eap/qe/ts/common/docker/MalformedDockerConfigTest.java
@@ -8,10 +8,13 @@ import static org.jboss.eap.qe.ts.common.docker.Docker.DOCKER_CMD;
 
 import java.util.concurrent.TimeUnit;
 
+import org.jboss.eap.qe.ts.common.docker.junit.DockerRequiredTests;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
+@Category(DockerRequiredTests.class)
 public class MalformedDockerConfigTest {
 
     @Rule

--- a/tooling-server-configuration/src/test/java/org/jboss/eap/qe/microprofile/tooling/server/AddRemoveModuleTest.java
+++ b/tooling-server-configuration/src/test/java/org/jboss/eap/qe/microprofile/tooling/server/AddRemoveModuleTest.java
@@ -52,7 +52,7 @@ public class AddRemoveModuleTest {
         // verify that module was added
         File modulesRoot = new File(System.getProperty("module.path"));
 
-        File module = new File(modulesRoot, TEST_MODULE_NAME.replaceAll("\\.", File.separator));
+        File module = new File(modulesRoot, TEST_MODULE_NAME.replace(".", File.separator));
         assertTrue("Module " + module.getAbsolutePath() + " should exist on path", module.exists());
 
         File moduleTestJar1 = new File(module, "main" + File.separator + "testJar1.jar");


### PR DESCRIPTION
- Fixing usage of `java.nio.Paths.get()` and `String.replaceAll()` usages, in order to let the implementation work on Linux and Windows as well
- Fixing MicroProfile OpenAPI failures on Windows
- Filtering tests by JUnit 4 `@Category`
- Adding a Bootable JAR execution for the `micrometer` related tests

Fixes #294

Internal job CI verification reference:

- **XP 5 job**:  eap-8.x-microprofile-simple-face
- **XP 5 run**: 127
- **WildFly job**: eap-8.x-microprofile-simple-face
- **WildFly run**: 128

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] ~Link~ reference to the passing job is provided
- [x] Code is self-descriptive and/or documented
- **N/A** Description of the tests scenarios is included (see #46)