### PR TITLE
[issue 263](xp5) - Removing unneeded setup task class that disables all default procedures

### DIFF
--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/HealthNullTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/HealthNullTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.Matchers.is;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.tools.HealthUrlProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.deployment.ConfigurationUtil;
@@ -23,7 +22,6 @@ import io.restassured.http.ContentType;
 
 @RunAsClient
 @RunWith(Arquillian.class)
-@ServerSetup({ DisableDefaultHealthProceduresSetupTask.class })
 public class HealthNullTest {
 
     @Deployment(testable = false)

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MultiDeploymentHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/MultiDeploymentHealthTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.not;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.eap.qe.microprofile.health.tools.HealthUrlProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.ConfigurationException;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.deployment.ConfigurationUtil;
@@ -27,7 +26,6 @@ import io.restassured.http.ContentType;
  * Multiple deployment scenario.
  */
 @RunWith(Arquillian.class)
-@ServerSetup({ DisableDefaultHealthProceduresSetupTask.class })
 public class MultiDeploymentHealthTest {
 
     @Deployment(name = "deployment1", order = 1, testable = false)


### PR DESCRIPTION
Backporting changes in #290, related to #263

- **Validation runs reference**:  
1. job: **eap-8.x-microprofile-testsuite** 
2. run nr.: **1078** :heavy_check_mark:  (the MP Health related failures here are unrelated and are due to #298)
 
---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] ~Link~ Reference to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)