### PR TITLE
[issues-298] - Fix MicroProfile Health tests in order to check the suspend-state probe too

### DIFF
--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/DefaultReadinessProcedureHealthTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/DefaultReadinessProcedureHealthTest.java
@@ -75,13 +75,13 @@ public class DefaultReadinessProcedureHealthTest {
                 .statusCode(HttpStatus.SC_OK)
                 .contentType(ContentType.JSON)
                 .body("status", is("UP"),
-                        "checks", hasSize(6),
+                        "checks", hasSize(7),
                         "checks.status", hasItems("UP", "UP"),
                         "checks.name",
-                        containsInAnyOrder("deployments-status", "boot-errors", "server-state",
+                        containsInAnyOrder("deployments-status", "boot-errors", "server-state", "suspend-state",
                                 String.format("ready-deployment.%s", ARCHIVE_NAME),
                                 String.format("started-deployment.%s", ARCHIVE_NAME), "live"),
-                        "checks.data", hasSize(6),
+                        "checks.data", hasSize(7),
                         "checks.find{it.name == 'live'}.data.key", is("value"));
     }
 
@@ -119,15 +119,16 @@ public class DefaultReadinessProcedureHealthTest {
         RestAssured.get(HealthUrlProvider.readyEndpoint()).then()
                 .contentType(ContentType.JSON)
                 .body("status", is("UP"),
-                        "checks", hasSize(4),
+                        "checks", hasSize(5),
                         "checks.status", hasItems("UP"),
                         "checks.name",
-                        containsInAnyOrder("boot-errors", "server-state", "deployments-status",
+                        containsInAnyOrder("boot-errors", "server-state", "deployments-status", "suspend-state",
                                 readyDeploymentCheckName),
                         "checks.find{it.name == '" + readyDeploymentCheckName + "'}.data", is(nullValue()),
                         "checks.find{it.name == 'boot-errors'}.data", is(nullValue()),
                         "checks.find{it.name == 'deployments-status'}.data", is(notNullValue()),
-                        "checks.find{it.name == 'server-state'}.data.value", is("running"));
+                        "checks.find{it.name == 'server-state'}.data.value", is("running"),
+                        "checks.find{it.name == 'suspend-state'}.data.value", is("RUNNING"));
     }
 
     /**

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/delay/NotReadyHealthCheckTest.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/delay/NotReadyHealthCheckTest.java
@@ -41,7 +41,7 @@ import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 
 /**
- * Performs tests that aim to verify the MP Health check implementation in complex scenarios where delayed
+ * Performs tests that aim to verify the MP Health check implementation in complex scenarios, where delayed
  * readiness health checks could lead to misinterpretation of server/service status, see
  * https://issues.redhat.com/browse/WFLY-12952.
  * <p>
@@ -249,7 +249,7 @@ public class NotReadyHealthCheckTest {
                         .statusCode(503)
                         .body("status", is("DOWN"),
                                 "checks.name", containsInAnyOrder(DelayedReadinessHealthCheck.NAME, "deployments-status",
-                                        "boot-errors", "server-state"));
+                                        "boot-errors", "server-state", "suspend-state"));
             } finally {
                 controller.stop(ManualTests.ARQUILLIAN_CONTAINER);
             }
@@ -302,7 +302,7 @@ public class NotReadyHealthCheckTest {
                         .body("status", is("UP"),
                                 "checks.name", containsInAnyOrder(
                                         "ready-deployment." + DelayedLivenessHealthCheck.class.getSimpleName() + ".war",
-                                        "deployments-status", "boot-errors", "server-state"));
+                                        "deployments-status", "boot-errors", "server-state", "suspend-state"));
             } finally {
                 controller.stop(ManualTests.ARQUILLIAN_CONTAINER);
             }

--- a/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/delay/ReadinessChecker.java
+++ b/microprofile-health/src/test/java/org/jboss/eap/qe/microprofile/health/delay/ReadinessChecker.java
@@ -51,20 +51,20 @@ public class ReadinessChecker implements Callable<Boolean> {
                         if (response.getStatusCode() == 503) {
                             if (checks == null) {
                                 addState(DOWN_NO_CONTENT());
-                            } else if ((checks.size() == 4) && contains(checks, "empty-readiness-checks")) {
+                            } else if ((checks.size() == 5) && contains(checks, "empty-readiness-checks")) {
                                 addState(DOWN_NO_CHECK());
-                            } else if ((checks.size() == 4) && contains(checks, DelayedReadinessHealthCheck.NAME)) {
+                            } else if ((checks.size() == 5) && contains(checks, DelayedReadinessHealthCheck.NAME)) {
                                 addState(ReadinessState.DOWN_WITH_CHECK());
                             }
                         } else if (response.getStatusCode() == 200) {
                             if (checks == null) {
                                 throw new RuntimeException("Readiness probe is UP (200) however missing JSON content");
                             }
-                            if ((checks.size() == 4) && contains(checks, "empty-readiness-checks")) {
+                            if ((checks.size() == 5) && contains(checks, "empty-readiness-checks")) {
                                 addState(UP_NO_CHECK());
-                            } else if ((checks.size() == 4) && contains(checks, DelayedReadinessHealthCheck.NAME)) {
+                            } else if ((checks.size() == 5) && contains(checks, DelayedReadinessHealthCheck.NAME)) {
                                 addState(UP_WITH_CHECK());
-                            } else if ((checks.size() == 4) && contains(checks, DEFAULT_READINESS_CHECK_NAME_PREFIX)) {
+                            } else if ((checks.size() == 5) && contains(checks, DEFAULT_READINESS_CHECK_NAME_PREFIX)) {
                                 addState(UP_WITH_DEFAULT_CHECK());
                             }
                         }


### PR DESCRIPTION
SSIA, to align the master branch with [WFLY-18176](https://issues.redhat.com/browse/WFLY-18176)

Fix #298

**Relevant CI runs reference**: job: **eap-8.x-microprofile-simple-face**, run nr. **149**. Some recurring failures in `DefaultReadinessProcedureHealthTest` on RHEL 9 were noticed, although they are fixed in subsequent runs, e.g.: **eap-8.x-microprofile-testsuite-bootable** nr. **581** and **eap-8.x-microprofile-testsuite** nr. **1094**.
Such instability is out of scope here, and will be investigated separately.

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] ~Link~ Reference to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)