### PR TITLE
Fixing AbstractKeyLoader which is handling the PK value badly

### DIFF
--- a/tooling-mp-jwt-auth-tool/src/main/java/org/jboss/eap/qe/microprofile/jwt/auth/tool/AbstractKeyLoader.java
+++ b/tooling-mp-jwt-auth-tool/src/main/java/org/jboss/eap/qe/microprofile/jwt/auth/tool/AbstractKeyLoader.java
@@ -46,7 +46,7 @@ public abstract class AbstractKeyLoader<PRIVATE_KEY, PUBLIC_KEY> {
             String privateKeyPEM = key.toString()
                     .replace("-----BEGIN PRIVATE KEY-----", "")
                     .replaceAll(System.lineSeparator(), "")
-                    .replace("-----BEGIN PRIVATE KEY-----", "");
+                    .replace("-----END PRIVATE KEY-----", "");
 
             byte[] encoded = Base64.decodeBase64(privateKeyPEM);
 


### PR DESCRIPTION
Visible only on JDK 21, since https://bugs.openjdk.org/browse/JDK-8308010 has been resolved.

Fixes #300 

**CI runs reference**
- Regular execution: **job**: eap-8.x-microprofile-testsuite, **nr.** 1104
- Bootable JAR execution: **job**: eap-8.x-microprofile-testsuite-bootable, **nr.** 584

Failures in Micrometer are unrelated and visible on master

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] ~Link~ Reference to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)