### PR TITLE
[issues-301] - Add a GitHub workflow to run integration tests against the default WildFly version

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -1,0 +1,36 @@
+name: WildFly/EAP MicroProfile Test Suite Integration Tests
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  wildfly-it-tests:
+    if: '! github.event.pull_request.draft'
+    runs-on: [ubuntu-latest, windows-latest]
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: ['11', '17']
+        java-distribution: ['adopt', 'oracle']
+    steps:
+      - name: Checkout eap-microprofile-test-suite
+        uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java-distribution }} ${{ matrix.java-version }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: ${{ matrix.java-distribution }}
+          cache: 'maven'
+      - name: Build and run integration tests (${{ matrix.java-distribution }} ${{ matrix.java }}) against latest WildFly
+        run: |
+          ./mvnw clean verify
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: surefire-reports-jdk-${{ matrix.java }}
+          path: |
+            '${{ github.workspace }}/**/surefire-reports/*.*'
+            '${{ github.workspace }}/**/*.log'

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <version.org.eclipse.microprofile.lra>2.0</version.org.eclipse.microprofile.lra>
         <version.io.micrometer>1.12.4</version.io.micrometer>
         <version.org.jboss.arquillian>1.7.2.Final</version.org.jboss.arquillian>
-        <version.org.jboss.wildfly.dist>32.0.1.Final</version.org.jboss.wildfly.dist>
+        <version.org.jboss.wildfly.dist>34.0.0.Beta1</version.org.jboss.wildfly.dist>
         <version.org.wildfly.arquillian>5.0.1.Final</version.org.wildfly.arquillian>
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
         <version.io.undertow.undertow-core>2.3.0.Alpha2</version.io.undertow.undertow-core>
@@ -61,7 +61,7 @@
         <version.org.eclipse.microprofile.jwt.microprofile-jwt-auth-api>2.1</version.org.eclipse.microprofile.jwt.microprofile-jwt-auth-api>
         <!-- wildfly-core update needed to have the launcher version with BootableJarCommandBuilder used to start
         the server up -->
-        <version.org.wildfly.core>24.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>26.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>2.0.2</version.org.wildfly.extras.creaper>
         <version.org.yaml.snakeyaml>1.33</version.org.yaml.snakeyaml>
         <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
@@ -78,9 +78,9 @@
         <galleon.log.time>true</galleon.log.time>
         <testsuite.galleon.pack.groupId>org.wildfly</testsuite.galleon.pack.groupId>
         <testsuite.galleon.pack.artifactId>wildfly-galleon-pack</testsuite.galleon.pack.artifactId>
-        <testsuite.galleon.pack.version>31.0.0.Final</testsuite.galleon.pack.version>
+        <testsuite.galleon.pack.version>${version.org.jboss.wildfly.dist}</testsuite.galleon.pack.version>
         <!-- Bootable JAR -->
-        <version.org.wildfly.jar.plugin>11.0.0.Beta1</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>11.0.2.Final</version.org.wildfly.jar.plugin>
         <version.org.bitbucket.b_c.jose4j>0.7.4</version.org.bitbucket.b_c.jose4j>
         <version.org.eclipse.parsson>1.1.5</version.org.eclipse.parsson>
 


### PR DESCRIPTION
This is for running automated CI checks against the WildFly version which is set by related properties default values, in order to implement CI checks upstream.

Resolves #301 

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- **N/A** Description of the tests scenarios is included (see #46)