### PR TITLE
[issues-301] - Add a GitHub workflow to run integration tests against the default WildFly version

### DIFF
--- a/.github/workflows/wildfly-it-tests-bootable.yml
+++ b/.github/workflows/wildfly-it-tests-bootable.yml
@@ -1,0 +1,41 @@
+name: WildFly Bootable JAR Integration Tests
+
+on:
+  push:
+    branches: [ 'master' ]
+  pull_request:
+    branches: [ 'master' ]
+
+jobs:
+  wildfly-it-tests:
+    if: '! github.event.pull_request.draft'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest']
+        java-version: ['17', '21']
+        java-distribution: ['adopt']
+    steps:
+      - name: Checkout eap-microprofile-test-suite
+        uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java-distribution }} ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.java-distribution }}
+          cache: 'maven'
+      - name: Build and run integration tests (${{ matrix.java-distribution }} ${{ matrix.java-version }}) against latest WildFly, on ${{ matrix.os }}
+        if: ${{ matrix.os  == 'ubuntu-latest' }}
+        run: mvn clean verify --batch-mode -fae "-Dts.bootable" "-Dcurrent-execution.excluded-groups=org.jboss.eap.qe.microprofile.health.junit.HealthWithFaultToleranceTests,org.jboss.eap.qe.microprofile.health.junit.ManualTests"
+      - name: Build and run integration tests (${{ matrix.java-distribution }} ${{ matrix.java-version }}) against latest WildFly, on ${{ matrix.os }} (excluding Docker)
+        if: ${{ matrix.os  == 'windows-latest' }}
+        run: mvn clean verify --batch-mode -fae "-Dts.bootable" "-Dcurrent-execution.excluded-groups=org.jboss.eap.qe.microprofile.health.junit.HealthWithFaultToleranceTests,org.jboss.eap.qe.microprofile.health.junit.ManualTests,org.jboss.eap.qe.ts.common.docker.junit.DockerRequiredTests"
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: surefire-reports-server-logs-jdk-${{ matrix.java-distribution }}-${{ matrix.java-version }}
+          path: |
+            **/target/surefire-reports/*
+            **/standalone/log/*

--- a/.github/workflows/wildfly-it-tests.yml
+++ b/.github/workflows/wildfly-it-tests.yml
@@ -1,0 +1,41 @@
+name: WildFly Integration Tests
+
+on:
+  push:
+    branches: [ 'master' ]
+  pull_request:
+    branches: [ 'master' ]
+
+jobs:
+  wildfly-it-tests:
+    if: '! github.event.pull_request.draft'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest']
+        java-version: ['17', '21']
+        java-distribution: ['adopt']
+    steps:
+      - name: Checkout eap-microprofile-test-suite
+        uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java-distribution }} ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.java-distribution }}
+          cache: 'maven'
+      - name: Build and run integration tests (${{ matrix.java-distribution }} ${{ matrix.java-version }}) against latest WildFly, on ${{ matrix.os }}
+        if: ${{ matrix.os  == 'ubuntu-latest' }}
+        run: mvn clean verify --batch-mode -fae
+      - name: Build and run integration tests (${{ matrix.java-distribution }} ${{ matrix.java-version }}) against latest WildFly, on ${{ matrix.os }} (excluding Docker)
+        if: ${{ matrix.os  == 'windows-latest' }}
+        run: mvn clean verify --batch-mode -fae "-Dcurrent-execution.excluded-groups=org.jboss.eap.qe.ts.common.docker.junit.DockerRequiredTests"
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: surefire-reports-server-logs-jdk-${{ matrix.java-distribution }}-${{ matrix.java-version }}
+          path: |
+            **/target/surefire-reports/*
+            **/standalone/log/*

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakIntegrationHighLevelScenarioTest.java
@@ -62,7 +62,6 @@ public class KeycloakIntegrationHighLevelScenarioTest {
             .withEnvVar("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_ADMIN_PASSWORD)
             .withEnvVar("KC_HEALTH_ENABLED", "true")
             .withCmdArg("start-dev")
-            .withCmdArg("--log-level=DEBUG")
             .build();
 
     public static KeycloakConfigurator keycloakConfigurator = new KeycloakConfigurator.Builder(KEYCLOAK_REALM_NAME)

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <version.org.eclipse.microprofile.lra>2.0</version.org.eclipse.microprofile.lra>
         <version.io.micrometer>1.12.4</version.io.micrometer>
         <version.org.jboss.arquillian>1.7.2.Final</version.org.jboss.arquillian>
-        <version.org.jboss.wildfly.dist>32.0.1.Final</version.org.jboss.wildfly.dist>
+        <version.org.jboss.wildfly.dist>34.0.0.Final</version.org.jboss.wildfly.dist>
         <version.org.wildfly.arquillian>5.0.1.Final</version.org.wildfly.arquillian>
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
         <version.io.undertow.undertow-core>2.3.0.Alpha2</version.io.undertow.undertow-core>
@@ -61,7 +61,7 @@
         <version.org.eclipse.microprofile.jwt.microprofile-jwt-auth-api>2.1</version.org.eclipse.microprofile.jwt.microprofile-jwt-auth-api>
         <!-- wildfly-core update needed to have the launcher version with BootableJarCommandBuilder used to start
         the server up -->
-        <version.org.wildfly.core>24.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>26.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>2.0.2</version.org.wildfly.extras.creaper>
         <version.org.yaml.snakeyaml>1.33</version.org.yaml.snakeyaml>
         <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
@@ -78,9 +78,9 @@
         <galleon.log.time>true</galleon.log.time>
         <testsuite.galleon.pack.groupId>org.wildfly</testsuite.galleon.pack.groupId>
         <testsuite.galleon.pack.artifactId>wildfly-galleon-pack</testsuite.galleon.pack.artifactId>
-        <testsuite.galleon.pack.version>31.0.0.Final</testsuite.galleon.pack.version>
+        <testsuite.galleon.pack.version>${version.org.jboss.wildfly.dist}</testsuite.galleon.pack.version>
         <!-- Bootable JAR -->
-        <version.org.wildfly.jar.plugin>11.0.0.Beta1</version.org.wildfly.jar.plugin>
+        <version.org.wildfly.jar.plugin>11.0.2.Final</version.org.wildfly.jar.plugin>
         <version.org.bitbucket.b_c.jose4j>0.7.4</version.org.bitbucket.b_c.jose4j>
         <version.org.eclipse.parsson>1.1.5</version.org.eclipse.parsson>
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <!-- wildfly-core update needed to have the launcher version with BootableJarCommandBuilder used to start
         the server up -->
         <version.org.wildfly.core>26.0.1.Final</version.org.wildfly.core>
-        <version.org.wildfly.extras.creaper>2.0.2</version.org.wildfly.extras.creaper>
+        <version.org.wildfly.extras.creaper>2.0.3</version.org.wildfly.extras.creaper>
         <version.org.yaml.snakeyaml>1.33</version.org.yaml.snakeyaml>
         <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
         <version.com.fasterxml.jackson.core.jackson-databind>2.9.9.1</version.com.fasterxml.jackson.core.jackson-databind>
@@ -83,6 +83,7 @@
         <version.org.wildfly.jar.plugin>11.0.2.Final</version.org.wildfly.jar.plugin>
         <version.org.bitbucket.b_c.jose4j>0.7.4</version.org.bitbucket.b_c.jose4j>
         <version.org.eclipse.parsson>1.1.5</version.org.eclipse.parsson>
+        <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
 
         <!-- XP Channel manifest GAV -->
         <channel-manifest.groupId>org.jboss.eap.channels</channel-manifest.groupId>
@@ -100,6 +101,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${version.org.jboss.logging.jboss-logging}</version>
+            </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile</groupId>
                 <artifactId>microprofile</artifactId>


### PR DESCRIPTION
This is for running automated CI checks against the WildFly version which is set by related properties default values, in order to implement CI checks upstream.

Resolves #301 

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- **N/A** Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- **N/A** Description of the tests scenarios is included (see #46)