### PR TITLE
[issues-307] - Freeze the opentelemetry-collector-contrib tag to 0.103.1

### DIFF
--- a/micrometer/src/test/java/org/jboss/eap/qe/micrometer/container/OpenTelemetryCollectorContainer.java
+++ b/micrometer/src/test/java/org/jboss/eap/qe/micrometer/container/OpenTelemetryCollectorContainer.java
@@ -79,7 +79,7 @@ public class OpenTelemetryCollectorContainer {
 
     private OpenTelemetryCollectorContainer() {
         otelCollector = new Docker.Builder("otel-collector",
-                "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest")
+                "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.103.1")
                 .setContainerReadyCondition(() -> {
                     try {
                         new Socket("127.0.0.1", HEALTH_CHECK_PORT).close();


### PR DESCRIPTION
Freezing the OTel collector image version to 0.103.1, to avoid braking changes in the latest version configuration schema, and to be aligned with [the tag used by the WildFly test suite](https://github.com/wildfly/wildfly/blob/main/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java#L24).

Fixes #307

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] ~Link~ to the passing job is provided
- [x] Code is self-descriptive and/or documented
- **N/A** Description of the tests scenarios is included (see #46)