### PR TITLE
Add a GitHub workflow to run the tests manually

### DIFF
--- a/.github/workflows/wildfly-it-tests-manual-bootable.yml
+++ b/.github/workflows/wildfly-it-tests-manual-bootable.yml
@@ -1,0 +1,81 @@
+name: WildFly Integration Tests (Bootable JAR) - Manual execution
+
+on:
+  workflow_dispatch:
+    inputs:
+      wildfly-jar-maven-plugin-version:
+        description: 'The WildFly JAR Maven (Bootable JAR) plugin version that will be used when running the tests'
+        required: false
+        default: ""
+        type: string
+      build-wildFly:
+        description: 'Whether to build a custom WildFly snapshot to run the tests with'
+        required: true
+        default: false
+        type: boolean
+      wildFly-repo:
+        description: 'The WildFly repository that will be used to build the snapshot from'
+        required: false
+        default: "wildfly/wildfly"
+        type: string
+      wildFly-ref:
+        description: 'The WildFly branch that will be used to build the snapshot from'
+        required: false
+        default: "main"
+        type: string
+
+jobs:
+  wildfly-it-tests-manual-bootable:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest'] # let's skip windows for now, ugly "file name too long error poppin' up currently": , 'windows-latest']
+        java-version: ['17', '21']
+        java-distribution: ['adopt']
+    steps:
+      - name: Checkout eap-microprofile-test-suite
+        uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java-distribution }} ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.java-distribution }}
+          cache: 'maven'
+      - name: Checkout and build WildFly
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.wildFly-repo }}
+          ref: ${{ inputs.wildFly-ref }}
+          path: 'local-wildfly'
+        if: ${{ inputs.build-wildFly == true }}
+      - name: Build WildFly
+        run: cd local-wildfly ; mvn clean install -DskipTests --batch-mode; cd ..
+        if: ${{ inputs.build-wildFly == true }}
+      - name: Set the value for the ENV VAR that stores the WildFly version
+        run: |
+          echo "MAVEN_ARGS_WILDFLY_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout -f local-wildfly/pom.xml)" >> "$GITHUB_ENV"
+        if: ${{ inputs.build-wildFly == true }}
+      - name: Set the value for the ENV VAR that stores the WildFly snapshot distribution version property
+        run: |
+          echo "MAVEN_ARGS_WILDFLY_DIST_VERSION=-Dversion.org.jboss.wildfly.dist=${{ env.MAVEN_ARGS_WILDFLY_VERSION }}" >> "$GITHUB_ENV"
+        if: ${{ inputs.build-wildFly == true }}
+      - name: Set the value for the ENV VAR that stores the WildFly snapshot distribution location property
+        run: |
+          echo "MAVEN_ARGS_WILDFLY_DIST_LOCATION=-Djboss.dist=${PWD}/local-wildfly/dist/target/wildfly-${{ env.MAVEN_ARGS_WILDFLY_VERSION }}" >> "$GITHUB_ENV"
+        if: ${{ inputs.build-wildFly == true }}
+      - name: Set the value for the WildFly JAR (Bootable JAR) Maven plugin version
+        run: |
+          echo "MAVEN_ARGS_WILDFLY_JAR_MAVEN_PLUGIN_VERSION=-Dversion.org.wildfly.jar.plugin=${{ inputs.wildfly-jar-maven-plugin-version }}" >> "$GITHUB_ENV"
+        if: ${{ ! inputs.wildfly-jar-maven-plugin-version == '' }}
+      - name: Build and run integration tests (${{ matrix.java-distribution }} ${{ matrix.java-version }}) against latest WildFly, on ${{ matrix.os }}
+        if: ${{ matrix.os  == 'ubuntu-latest' }}
+        run: mvn clean verify --batch-mode -fae ${{ env.MAVEN_ARGS_WILDFLY_DIST_LOCATION }} ${{ env.MAVEN_ARGS_WILDFLY_DIST_VERSION }} ${{ env.MAVEN_ARGS_WILDFLY_JAR_MAVEN_PLUGIN_VERSION }}
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: surefire-reports-server-logs-jdk-${{ matrix.java-distribution }}-${{ matrix.java-version }}
+          path: |
+            **/target/surefire-reports/*
+            **/standalone/log/*

--- a/.github/workflows/wildfly-it-tests-manual.yml
+++ b/.github/workflows/wildfly-it-tests-manual.yml
@@ -1,0 +1,72 @@
+name: WildFly Integration Tests - Manual execution
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-wildFly:
+        description: 'Whether to build a custom WildFly snapshot to run the tests with'
+        required: true
+        default: false
+        type: boolean
+      wildFly-repo:
+        description: 'The WildFly repository that will be used to build the snapshot from'
+        required: false
+        default: "wildfly/wildfly"
+        type: string
+      wildFly-ref:
+        description: 'The WildFly branch that will be used to build the snapshot from'
+        required: false
+        default: "main"
+        type: string
+
+jobs:
+  wildfly-it-tests-manual:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest'] # let's skip windows for now, ugly "file name too long error poppin' up currently": , 'windows-latest']
+        java-version: ['17', '21']
+        java-distribution: ['adopt']
+    steps:
+      - name: Checkout eap-microprofile-test-suite
+        uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java-distribution }} ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.java-distribution }}
+          cache: 'maven'
+      - name: Checkout and build WildFly
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.wildFly-repo }}
+          ref: ${{ inputs.wildFly-ref }}
+          path: 'local-wildfly'
+        if: ${{ inputs.build-wildFly == true }}
+      - name: Build WildFly
+        run: cd local-wildfly ; mvn clean install -DskipTests --batch-mode; cd ..
+        if: ${{ inputs.build-wildFly == true }}
+      - name: Set the value for the ENV VAR that stores the WildFly version
+        run: |
+          echo "MAVEN_ARGS_WILDFLY_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout -f local-wildfly/pom.xml)" >> "$GITHUB_ENV"
+        if: ${{ inputs.build-wildFly == true }}
+      - name: Set the value for the ENV VAR that stores the WildFly snapshot distribution version property
+        run: |
+          echo "MAVEN_ARGS_WILDFLY_DIST_VERSION=-Dversion.org.jboss.wildfly.dist=${{ env.MAVEN_ARGS_WILDFLY_VERSION }}" >> "$GITHUB_ENV"
+        if: ${{ inputs.build-wildFly == true }}
+      - name: Set the value for the ENV VAR that stores the WildFly snapshot distribution location property
+        run: |
+          echo "MAVEN_ARGS_WILDFLY_DIST_LOCATION=-Djboss.dist=${PWD}/local-wildfly/dist/target/wildfly-${{ env.MAVEN_ARGS_WILDFLY_VERSION }}" >> "$GITHUB_ENV"
+        if: ${{ inputs.build-wildFly == true }}
+      - name: Build and run integration tests (${{ matrix.java-distribution }} ${{ matrix.java-version }}) against latest WildFly, on ${{ matrix.os }}
+        if: ${{ matrix.os  == 'ubuntu-latest' }}
+        run: mvn clean verify --batch-mode -fae  ${{ env.MAVEN_ARGS_WILDFLY_DIST_LOCATION }} ${{ env.MAVEN_ARGS_WILDFLY_DIST_VERSION }}
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: surefire-reports-server-logs-jdk-${{ matrix.java-distribution }}-${{ matrix.java-version }}
+          path: |
+            **/target/surefire-reports/*
+            **/standalone/log/*


### PR DESCRIPTION
This is to add a GitHub workflow for allowing users to trigger tests against a given WildFly version, or the default which is configured via the project properties in the POM file.

- **N.B.**: the workflow runs on Linux based runners only ATM, since a "file name too long" exception pops up when executing the WildFly build on Windows. 
- **CI runs**:
1. With custom Wildfly, [regular execution](https://github.com/fabiobrz/eap-microprofile-test-suite/actions/runs/11783212556)
2. With custom WildFly, [bootable execution
](https://github.com/fabiobrz/eap-microprofile-test-suite/actions/runs/11783202932)
3. With default WildFly, [regular execution](https://github.com/fabiobrz/eap-microprofile-test-suite/actions/runs/11783519885)
4. With default WildFly, [bootable execution](https://github.com/fabiobrz/eap-microprofile-test-suite/actions/runs/11783515290)

_The failure in the `microprofile-fault-tolerance` DatabaseCrashTest is unrelated_

Resolves #311

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)