### PR TITLE
Fix Fault Tolerance multiple metrics provider test

### DIFF
--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -146,6 +146,7 @@
                                     <layers>
                                         <layer>cloud-server</layer>
                                         <layer>microprofile-fault-tolerance</layer>
+                                        <layer>micrometer</layer>
                                     </layers>
                                 </configuration>
                             </execution>

--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/UndeployDeployTest.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/UndeployDeployTest.java
@@ -17,6 +17,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.eap.qe.microprofile.common.setuptasks.MicroProfileFaultToleranceServerConfiguration;
 import org.jboss.eap.qe.microprofile.common.setuptasks.MicroProfileTelemetryServerConfiguration;
 import org.jboss.eap.qe.microprofile.common.setuptasks.MicrometerServerConfiguration;
+import org.jboss.eap.qe.microprofile.common.setuptasks.OpenTelemetryServerConfiguration;
 import org.jboss.eap.qe.microprofile.fault.tolerance.deployments.v10.HelloService;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
 import org.jboss.eap.qe.microprofile.tooling.server.configuration.deployment.ConfigurationUtil;
@@ -142,8 +143,8 @@ public class UndeployDeployTest {
             otelCollector.start();
             try {
                 // Enable MP Telemetry based metrics, which rely on OpenTelemetry subsystem
-                MicroProfileTelemetryServerConfiguration.enableOpenTelemetry();
-                MicroProfileTelemetryServerConfiguration
+                OpenTelemetryServerConfiguration.enableOpenTelemetry();
+                OpenTelemetryServerConfiguration
                         .addOpenTelemetryCollectorConfiguration(otelCollector.getOtlpGrpcEndpoint());
                 MicroProfileTelemetryServerConfiguration.enableMicroProfileTelemetry();
                 try {
@@ -213,7 +214,7 @@ public class UndeployDeployTest {
                 } finally {
                     // disable MP Telemetry based metrics
                     MicroProfileTelemetryServerConfiguration.disableMicroProfileTelemetry();
-                    MicroProfileTelemetryServerConfiguration.disableOpenTelemetry();
+                    OpenTelemetryServerConfiguration.disableOpenTelemetry();
                 }
             } finally {
                 // stop the OTel collector container

--- a/microprofile-telemetry/src/test/java/org/jboss/eap/qe/microprofile/telemetry/metrics/MPTelemetryServerSetupTask.java
+++ b/microprofile-telemetry/src/test/java/org/jboss/eap/qe/microprofile/telemetry/metrics/MPTelemetryServerSetupTask.java
@@ -4,6 +4,7 @@ import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.eap.qe.microprofile.common.setuptasks.MicroProfileTelemetryServerConfiguration;
 import org.jboss.eap.qe.microprofile.common.setuptasks.MicrometerServerConfiguration;
+import org.jboss.eap.qe.microprofile.common.setuptasks.OpenTelemetryServerConfiguration;
 import org.jboss.eap.qe.observability.containers.OpenTelemetryCollectorContainer;
 import org.jboss.eap.qe.ts.common.docker.Docker;
 
@@ -31,8 +32,8 @@ public class MPTelemetryServerSetupTask implements ServerSetupTask {
         otelCollector = OpenTelemetryCollectorContainer.getInstance();
         otelCollector.start();
         // Enable MP Telemetry based metrics, which rely on OpenTelemetry subsystem
-        MicroProfileTelemetryServerConfiguration.enableOpenTelemetry();
-        MicroProfileTelemetryServerConfiguration.addOpenTelemetryCollectorConfiguration(otelCollector.getOtlpGrpcEndpoint());
+        OpenTelemetryServerConfiguration.enableOpenTelemetry();
+        OpenTelemetryServerConfiguration.addOpenTelemetryCollectorConfiguration(otelCollector.getOtlpGrpcEndpoint());
         MicroProfileTelemetryServerConfiguration.enableMicroProfileTelemetry();
     }
 
@@ -43,7 +44,7 @@ public class MPTelemetryServerSetupTask implements ServerSetupTask {
     public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
         // disable MP Telemetry based metrics
         MicroProfileTelemetryServerConfiguration.disableMicroProfileTelemetry();
-        MicroProfileTelemetryServerConfiguration.disableOpenTelemetry();
+        OpenTelemetryServerConfiguration.disableOpenTelemetry();
         // stop the OTel collector container
         otelCollector.stop();
     }

--- a/tooling-observability/src/main/java/org/jboss/eap/qe/observability/containers/OpenTelemetryCollectorContainer.java
+++ b/tooling-observability/src/main/java/org/jboss/eap/qe/observability/containers/OpenTelemetryCollectorContainer.java
@@ -124,7 +124,7 @@ public class OpenTelemetryCollectorContainer {
      * Static method to get a unique instance of {@link OpenTelemetryCollectorContainer}.
      *
      * @param jaegerBackendContainer A {@link JaegerContainer} instance that will be used as the Jaeger backend, e.g.:
-     *                               for storing and retrieving traces.
+     *        for storing and retrieving traces.
      * @return A unique instance of {@link OpenTelemetryCollectorContainer}
      */
     public static synchronized OpenTelemetryCollectorContainer getInstance(JaegerContainer jaegerBackendContainer) {
@@ -150,7 +150,7 @@ public class OpenTelemetryCollectorContainer {
      * external code.
      *
      * @param jaegerBackendContainer A {@link JaegerContainer} instance that will be used as the Jaeger backend, e.g.:
-     *                               for storing and retrieving traces.
+     *        for storing and retrieving traces.
      * @return An instance of {@link OpenTelemetryCollectorContainer}
      */
     public static synchronized OpenTelemetryCollectorContainer getNewInstance(JaegerContainer jaegerBackendContainer) {

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/common/setuptasks/MicroProfileTelemetryServerConfiguration.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/common/setuptasks/MicroProfileTelemetryServerConfiguration.java
@@ -7,38 +7,13 @@ import org.wildfly.extras.creaper.core.online.operations.Operations;
 import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 
 /**
- * Operations required to set up the server for MicroProfile Telemetry
+ * Operations required to set up and configure the {@code microprofile-telemetry} extension
  */
 public class MicroProfileTelemetryServerConfiguration {
-    private static final Address OPENTELEMETRY_EXTENSION_ADDRESS = Address
-            .extension("org.wildfly.extension.opentelemetry");
-    private static final Address OPENTELEMETRY_SUBSYSTEM_ADDRESS = Address
-            .subsystem("opentelemetry");
-
     private static final Address MICROPROFILE_TELEMETRY_EXTENSION_ADDRESS = Address
             .extension("org.wildfly.extension.microprofile.telemetry");
     private static final Address MICROPROFILE_TELEMETRY_SUBSYSTEM_ADDRESS = Address
             .subsystem("microprofile-telemetry");
-
-    /**
-     * Checks whether <b>"org.wildfly.extension.opentelemetry"</b> extension is present
-     *
-     * @return True if extension is already present,false otherwise
-     * @throws Exception exception thrown by the internal operation executed by {@link Operations} API
-     */
-    public static Boolean openTelemetryExtensionExists(Operations operations) throws Exception {
-        return operations.exists(OPENTELEMETRY_EXTENSION_ADDRESS);
-    }
-
-    /**
-     * Checks whether <b>"opentelemetry"</b> subsystem is present
-     *
-     * @return True if extension is already present,false otherwise
-     * @throws Exception exception thrown by the internal operation executed by {@link Operations} API
-     */
-    public static Boolean openTelemetrySubsystemExists(Operations operations) throws Exception {
-        return operations.exists(OPENTELEMETRY_SUBSYSTEM_ADDRESS);
-    }
 
     /**
      * Checks whether <b>"org.wildfly.extension.microprofile.telemetry"</b> extension is present
@@ -58,91 +33,6 @@ public class MicroProfileTelemetryServerConfiguration {
      */
     public static Boolean microProfileTelemetrySubsystemExists(Operations operations) throws Exception {
         return operations.exists(MICROPROFILE_TELEMETRY_SUBSYSTEM_ADDRESS);
-    }
-
-    /**
-     * Enable OpenTelemetry extension and subsystem.
-     *
-     * @throws Exception exception thrown by the internal operation executed by {@link OnlineManagementClient} API
-     */
-    public static void enableOpenTelemetry() throws Exception {
-        try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
-            enableOpenTelemetry(client);
-        }
-    }
-
-    /**
-     * Set a default, working OpenTelemetry subsystem configuration, e.g.: to set the OTLP receiver URL.
-     */
-    public static void addOpenTelemetryCollectorConfiguration(final String otlpCollectorEndpointUrl) throws Exception {
-        try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
-            addOpenTelemetryCollectorConfiguration(otlpCollectorEndpointUrl, client);
-        }
-    }
-
-    /**
-     * Set a default, working OpenTelemetry subsystem configuration, e.g.: to set the OTLP receiver URL.
-     *
-     * @param client {@link OnlineManagementClient} instance used to execute the command
-     */
-    public static void addOpenTelemetryCollectorConfiguration(final String otlpCollectorEndpointUrl,
-            OnlineManagementClient client) throws Exception {
-        Operations operations = new Operations(client);
-        if (!openTelemetrySubsystemExists(operations)) {
-            throw new IllegalStateException("OpenTelemetry subsystem not found");
-        }
-        operations.writeAttribute(OPENTELEMETRY_SUBSYSTEM_ADDRESS, "exporter-type", "otlp");
-        operations.writeAttribute(OPENTELEMETRY_SUBSYSTEM_ADDRESS, "sampler-type", "on");
-        operations.writeAttribute(OPENTELEMETRY_SUBSYSTEM_ADDRESS, "max-export-batch-size", "512");
-        operations.writeAttribute(OPENTELEMETRY_SUBSYSTEM_ADDRESS, "batch-delay", "1");
-        operations.writeAttribute(OPENTELEMETRY_SUBSYSTEM_ADDRESS, "max-queue-size", "1");
-        operations.writeAttribute(OPENTELEMETRY_SUBSYSTEM_ADDRESS, "endpoint", otlpCollectorEndpointUrl);
-        new Administration(client).reloadIfRequired();
-    }
-
-    /**
-     * Enable OpenTelemetry extension and subsystem.
-     *
-     * @param client {@link OnlineManagementClient} instance used to execute the command
-     * @throws Exception exception thrown by the internal operation executed by {@link OnlineManagementClient} API
-     */
-    public static void enableOpenTelemetry(OnlineManagementClient client) throws Exception {
-        Operations operations = new Operations(client);
-        if (!openTelemetryExtensionExists(operations)) {
-            operations.add(OPENTELEMETRY_EXTENSION_ADDRESS);
-        }
-        if (!openTelemetrySubsystemExists(operations)) {
-            operations.add(OPENTELEMETRY_SUBSYSTEM_ADDRESS);
-        }
-        new Administration(client).reloadIfRequired();
-    }
-
-    /**
-     * Disable OpenTelemetry subsystem and extension
-     *
-     * @throws Exception exception thrown by the internal operation executed by {@link OnlineManagementClient} API
-     */
-    public static void disableOpenTelemetry() throws Exception {
-        try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
-            disableOpenTelemetry(client);
-        }
-    }
-
-    /**
-     * Disable OpenTelemetry subsystem and extension
-     *
-     * @param client {@link OnlineManagementClient} instance used to execute the command
-     * @throws Exception exception thrown by the internal operation executed by {@link OnlineManagementClient} API
-     */
-    public static void disableOpenTelemetry(OnlineManagementClient client) throws Exception {
-        Operations operations = new Operations(client);
-        if (openTelemetrySubsystemExists(operations)) {
-            operations.remove(OPENTELEMETRY_SUBSYSTEM_ADDRESS);
-        }
-        if (openTelemetryExtensionExists(operations)) {
-            operations.remove(OPENTELEMETRY_EXTENSION_ADDRESS);
-        }
-        new Administration(client).reloadIfRequired();
     }
 
     /**

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/common/setuptasks/OpenTelemetryServerConfiguration.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/common/setuptasks/OpenTelemetryServerConfiguration.java
@@ -1,0 +1,121 @@
+package org.jboss.eap.qe.microprofile.common.setuptasks;
+
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
+
+/**
+ * Operations required to set up and configure the {@code opentelemetry} subsystem
+ */
+public class OpenTelemetryServerConfiguration {
+    private static final Address OPENTELEMETRY_EXTENSION_ADDRESS = Address
+            .extension("org.wildfly.extension.opentelemetry");
+    private static final Address OPENTELEMETRY_SUBSYSTEM_ADDRESS = Address
+            .subsystem("opentelemetry");
+
+    /**
+     * Checks whether <b>"org.wildfly.extension.opentelemetry"</b> extension is present
+     *
+     * @return True if extension is already present,false otherwise
+     * @throws Exception exception thrown by the internal operation executed by {@link Operations} API
+     */
+    public static Boolean openTelemetryExtensionExists(Operations operations) throws Exception {
+        return operations.exists(OPENTELEMETRY_EXTENSION_ADDRESS);
+    }
+
+    /**
+     * Checks whether <b>"opentelemetry"</b> subsystem is present
+     *
+     * @return True if extension is already present,false otherwise
+     * @throws Exception exception thrown by the internal operation executed by {@link Operations} API
+     */
+    public static Boolean openTelemetrySubsystemExists(Operations operations) throws Exception {
+        return operations.exists(OPENTELEMETRY_SUBSYSTEM_ADDRESS);
+    }
+
+    /**
+     * Enable OpenTelemetry extension and subsystem.
+     *
+     * @throws Exception exception thrown by the internal operation executed by {@link OnlineManagementClient} API
+     */
+    public static void enableOpenTelemetry() throws Exception {
+        try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+            enableOpenTelemetry(client);
+        }
+    }
+
+    /**
+     * Set a default, working OpenTelemetry subsystem configuration, e.g.: to set the OTLP receiver URL.
+     */
+    public static void addOpenTelemetryCollectorConfiguration(final String otlpCollectorEndpointUrl) throws Exception {
+        try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+            addOpenTelemetryCollectorConfiguration(otlpCollectorEndpointUrl, client);
+        }
+    }
+
+    /**
+     * Set a default, working OpenTelemetry subsystem configuration, e.g.: to set the OTLP receiver URL.
+     *
+     * @param client {@link OnlineManagementClient} instance used to execute the command
+     */
+    public static void addOpenTelemetryCollectorConfiguration(final String otlpCollectorEndpointUrl,
+            OnlineManagementClient client) throws Exception {
+        Operations operations = new Operations(client);
+        if (!openTelemetrySubsystemExists(operations)) {
+            throw new IllegalStateException("OpenTelemetry subsystem not found");
+        }
+        operations.writeAttribute(OPENTELEMETRY_SUBSYSTEM_ADDRESS, "exporter-type", "otlp");
+        operations.writeAttribute(OPENTELEMETRY_SUBSYSTEM_ADDRESS, "sampler-type", "on");
+        operations.writeAttribute(OPENTELEMETRY_SUBSYSTEM_ADDRESS, "max-export-batch-size", "512");
+        operations.writeAttribute(OPENTELEMETRY_SUBSYSTEM_ADDRESS, "max-queue-size", "1");
+        operations.writeAttribute(OPENTELEMETRY_SUBSYSTEM_ADDRESS, "endpoint", otlpCollectorEndpointUrl);
+        new Administration(client).reloadIfRequired();
+    }
+
+    /**
+     * Enable OpenTelemetry extension and subsystem.
+     *
+     * @param client {@link OnlineManagementClient} instance used to execute the command
+     * @throws Exception exception thrown by the internal operation executed by {@link OnlineManagementClient} API
+     */
+    public static void enableOpenTelemetry(OnlineManagementClient client) throws Exception {
+        Operations operations = new Operations(client);
+        if (!openTelemetryExtensionExists(operations)) {
+            operations.add(OPENTELEMETRY_EXTENSION_ADDRESS);
+        }
+        if (!openTelemetrySubsystemExists(operations)) {
+            operations.add(OPENTELEMETRY_SUBSYSTEM_ADDRESS);
+        }
+        new Administration(client).reloadIfRequired();
+    }
+
+    /**
+     * Disable OpenTelemetry subsystem and extension
+     *
+     * @throws Exception exception thrown by the internal operation executed by {@link OnlineManagementClient} API
+     */
+    public static void disableOpenTelemetry() throws Exception {
+        try (OnlineManagementClient client = ManagementClientProvider.onlineStandalone()) {
+            disableOpenTelemetry(client);
+        }
+    }
+
+    /**
+     * Disable OpenTelemetry subsystem and extension
+     *
+     * @param client {@link OnlineManagementClient} instance used to execute the command
+     * @throws Exception exception thrown by the internal operation executed by {@link OnlineManagementClient} API
+     */
+    public static void disableOpenTelemetry(OnlineManagementClient client) throws Exception {
+        Operations operations = new Operations(client);
+        if (openTelemetrySubsystemExists(operations)) {
+            operations.remove(OPENTELEMETRY_SUBSYSTEM_ADDRESS);
+        }
+        if (openTelemetryExtensionExists(operations)) {
+            operations.remove(OPENTELEMETRY_EXTENSION_ADDRESS);
+        }
+        new Administration(client).reloadIfRequired();
+    }
+}


### PR DESCRIPTION
Fixes tests introduced by https://github.com/jboss-eap-qe/eap-microprofile-test-suite/pull/316, as just regular executions were working, thanks to default server config.
Changes in here are to fix the test logic in order to work with Bootable JAR too.

**TL; DR;**

Other than fixing the multiple metrics provider test, I've refactored server config classes to isolate OTel subsystem

**Verification job runs**:
- [Regular execution]: eap-8.x-microprofile-testsuite - 1163
- [Bootable JAR execution] eap-8.x-microprofile-testsuite-bootable - 637

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)