### PR TITLE
[issue-320] - Fix the Bootable JAR variant manual workflow

### DIFF
--- a/.github/workflows/wildfly-it-tests-manual-bootable.yml
+++ b/.github/workflows/wildfly-it-tests-manual-bootable.yml
@@ -71,7 +71,7 @@ jobs:
         if: ${{ ! inputs.wildfly-jar-maven-plugin-version == '' }}
       - name: Build and run integration tests (${{ matrix.java-distribution }} ${{ matrix.java-version }}) against latest WildFly, on ${{ matrix.os }}
         if: ${{ matrix.os  == 'ubuntu-latest' }}
-        run: mvn clean verify --batch-mode -fae ${{ env.MAVEN_ARGS_WILDFLY_DIST_LOCATION }} ${{ env.MAVEN_ARGS_WILDFLY_DIST_VERSION }} ${{ env.MAVEN_ARGS_WILDFLY_JAR_MAVEN_PLUGIN_VERSION }}
+        run: mvn clean verify --batch-mode -fae "-Dts.bootable" "-Dcurrent-execution.excluded-groups=org.jboss.eap.qe.microprofile.health.junit.HealthWithFaultToleranceTests,org.jboss.eap.qe.microprofile.health.junit.ManualTests" ${{ env.MAVEN_ARGS_WILDFLY_DIST_LOCATION }} ${{ env.MAVEN_ARGS_WILDFLY_DIST_VERSION }} ${{ env.MAVEN_ARGS_WILDFLY_JAR_MAVEN_PLUGIN_VERSION }}
       - uses: actions/upload-artifact@v4
         if: failure()
         with:


### PR DESCRIPTION
SSIA

Resolves #320 

**Validation runs**:
- https://github.com/fabiobrz/eap-microprofile-test-suite/actions/runs/12699287377/job/35399611207 :white_check_mark: - just DatabaseCrashTest failing - which is tracked already by #321, and a new failure of `org.jboss.eap.qe.microprofile.telemetry.metrics.namefellow.MultipleDeploymentsMetricsTest.dataTest` which must be triaged and is not related.

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- **N/A** Description of the tests scenarios is included (see #46)