### PR TITLE
Set surefire `runOrder` to alphabetical for microprofile-health

### DIFF
--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -75,6 +75,19 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <!-- TODO: remove once https://issues.redhat.com/browse/WFLY-20325 is solved -->
+                <configuration>
+                    <runOrder>alphabetical</runOrder>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <!-- Test against Bootable JAR -->
         <profile>
@@ -108,6 +121,8 @@
                                             org.wildfly.arquillian:wildfly-arquillian-container-managed
                                         </classpathDependencyExclude>
                                     </classpathDependencyExcludes>
+                                    <!-- TODO: remove once https://issues.redhat.com/browse/WFLY-20325 is solved -->
+                                    <runOrder>alphabetical</runOrder>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Here we're setting the property to `alphabetical` for both the regulare and bootable execution of the `maven-surefire-plugin`.
 
Resolves #325 

Internal validation runs, specifically the Oracle JDKs related combos:

1. Regular execution: 
- **job**: eap-8.x-microprofile-testsuite 
- **run**: ~1221~ 1222 & 1223

2. Bootable JAR execution
- **job**: eap-8.x-microprofile-testsuite-bootable
- **run**: ~664~ 665 & 666

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] ~Link~ Reference to the passing job is provided
- [x] Code is self-descriptive and/or documented
- **N/A** Description of the tests scenarios is included (see #46)