### PR TITLE
Replace internal Docker APIs to let tests run containers with Arquillian Cube

### DIFF
--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -109,6 +109,22 @@
             <groupId>org.jboss.threads</groupId>
             <artifactId>jboss-threads</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.arquillian.cube</groupId>
+            <artifactId>arquillian-cube-docker-junit-rule</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.arquillian.cube</groupId>
+            <artifactId>arquillian-cube-docker-ftest-containerobject-dsl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakConfigurator.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakConfigurator.java
@@ -33,6 +33,9 @@ public class KeycloakConfigurator extends ExternalResource {
 
     private String rawAdminToken;
 
+    public static final String KEYCLOAK_INSTANCE_HOSTNAME = "localhost";
+    public static final int KEYCLOAK_EXPOSED_HTTP_PORT = 8179;
+
     @Override
     public void before() throws InterruptedException {
         rawAdminToken = authorizeAndObtainRawJwtForAdminInterface(adminUsername, adminPassword);

--- a/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakContainerAwaitStrategy.java
+++ b/microprofile-jwt/src/test/java/org/jboss/eap/qe/microprofile/jwt/keycloak/KeycloakContainerAwaitStrategy.java
@@ -1,0 +1,74 @@
+package org.jboss.eap.qe.microprofile.jwt.keycloak;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import org.arquillian.cube.docker.impl.client.config.Await;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.spi.Cube;
+import org.arquillian.cube.spi.await.AwaitStrategy;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
+
+/**
+ * Provides a custom waiting strategy for Arquillian Cube DOcker APIs to check that the Keycloak container was started
+ * successfully.
+ * <p>
+ * Used by {@link KeycloakIntegrationHighLevelScenarioTest}
+ * </p>
+ */
+public class KeycloakContainerAwaitStrategy implements AwaitStrategy {
+
+    Await params;
+    DockerClientExecutor dockerClientExecutor;
+    Cube<?> cube;
+
+    private static final long CONTAINER_READY_TIMEOUT = 2;
+    private static final TimeUnit CONTAINER_READY_TIMEOUT_TIME_UNIT = TimeUnit.MINUTES;
+
+    public KeycloakContainerAwaitStrategy() {
+    }
+
+    public void setCube(Cube<?> cube) {
+        this.cube = cube;
+    }
+
+    public void setDockerClientExecutor(DockerClientExecutor dockerClientExecutor) {
+        this.dockerClientExecutor = dockerClientExecutor;
+    }
+
+    public void setParams(Await params) {
+        this.params = params;
+    }
+
+    @Override
+    public boolean await() {
+        try {
+            Awaitility.await()
+                    .atMost(CONTAINER_READY_TIMEOUT, CONTAINER_READY_TIMEOUT_TIME_UNIT)
+                    .until(() -> isContainerReady(KeycloakConfigurator.KEYCLOAK_EXPOSED_HTTP_PORT));
+        } catch (ConditionTimeoutException ex) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean isContainerReady(int port) {
+        try {
+            URL url = new URL("http://" + KeycloakConfigurator.KEYCLOAK_INSTANCE_HOSTNAME + ":" + port + "/health/ready");
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+
+            boolean ready = connection.getResponseCode() == HttpURLConnection.HTTP_OK;
+            if (ready) {
+                System.out.println(
+                        "Let's wait additional 10 seconds before the post-start tasks (like creation of admin user) on container are done.");
+                Thread.sleep(10000L);
+            }
+            return ready;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
 
         <!-- Using JUnit @Category to dynamically select executed test groups, based on multiple factors (e.g.: regular vs. bootable and Linux vs. Windows executions -->
         <current-execution.excluded-groups></current-execution.excluded-groups>
+        <version.arquillian-cube>2.1.0.Alpha2</version.arquillian-cube>
     </properties>
 
     <dependencyManagement>
@@ -163,6 +164,23 @@
                 <artifactId>wildfly-arquillian-container-managed</artifactId>
                 <version>${version.org.wildfly.arquillian}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.arquillian.cube</groupId>
+                <artifactId>arquillian-cube-bom</artifactId>
+                <version>${version.arquillian-cube}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.arquillian.cube</groupId>
+                <artifactId>arquillian-cube-docker-ftest-containerobject</artifactId>
+                <version>${version.arquillian-cube}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.arquillian.cube</groupId>
+                <artifactId>arquillian-cube-docker-ftest-containerobject-dsl</artifactId>
+                <version>${version.arquillian-cube}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly</groupId>


### PR DESCRIPTION
The changes introduce the Arquillian Cube dependencies and replace the usage of the internal Docker APIs provided by the tooling-docker sub-module with Arquillian Cube Docker APIs. 

- MicroProfile JWT tests: `KeycloakIntegrationHighLevelScenarioTest`

Resolves #333 

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)