### PR TITLE
[EAPQE-4350] Increase timeout in HighCPUUtilsTest to accomodate RHEL10

### DIFF
--- a/tooling-cpu-load/src/test/java/org/jboss/eap/qe/microprofile/tooling/cpu/load/HighCPUUtilsTest.java
+++ b/tooling-cpu-load/src/test/java/org/jboss/eap/qe/microprofile/tooling/cpu/load/HighCPUUtilsTest.java
@@ -34,14 +34,14 @@ public class HighCPUUtilsTest {
         Assume.assumeNotNull("This test cannot be executed on this platform as ProcessUtils class was not " +
                 "implemented for it.", processUtils);
 
-        int loadDurationInSeconds = 10;
+        int loadDurationInSeconds = 30;
         Process cpuLoadProcess = new HighCPUUtils(processUtils).causeMaximumCPULoadOnContainer(
                 ProcessUtils.CPUCoreMask.ALL_CORES, Duration.ofSeconds(loadDurationInSeconds));
 
         ArquillianContainerProperties props = new ArquillianContainerProperties(
                 ArquillianDescriptorWrapper.getArquillianDescriptor());
         Awaitility.await("CPU load generator does not work and is not causing any CPU load.")
-                .atMost(org.awaitility.Duration.TEN_SECONDS)
+                .atMost(30, TimeUnit.SECONDS)
                 // max CPU load is 1.0, if for example 9 from 10 CPU cores are under 100% load than expected load is 0.9
                 // substract 0.02 is defining test load tolerance for the test as load might be slighly smaller like 0.98
                 .until(() -> getCpuLoad(getConnection(props.getDefaultManagementAddress(),


### PR DESCRIPTION
When attempting to run test on RHEL10, the currently set timeout is not sufficient for the CPU load to be generated which causes the test to fail.

I don't see any changes in RHEL10 that would cause this, and be fixable, so just increasing the timeout is the only solution I can see.

eap-8.x-microprofile-testsuite-atucek - 21 

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Link to the passing job is provided 
- [x] Code is self-descriptive and/or documented