### PR TITLE
Add MicroMeter Prometheus tests

### DIFF
--- a/micrometer/pom.xml
+++ b/micrometer/pom.xml
@@ -74,6 +74,19 @@
             <artifactId>wildfly-arquillian-container-managed</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+        </dependency>
+
     </dependencies>
 
     <profiles>

--- a/micrometer/src/test/java/org/jboss/eap/qe/micrometer/prometheus/MgmtUsersSetup.java
+++ b/micrometer/src/test/java/org/jboss/eap/qe/micrometer/prometheus/MgmtUsersSetup.java
@@ -1,0 +1,60 @@
+package org.jboss.eap.qe.micrometer.prometheus;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Utility class adding and removing management users. One user is with RBAC Monitor role, second without it.
+ */
+public class MgmtUsersSetup {
+    private static final Path MGMT_USERS_FILE;
+    private static final Path MGMT_GROUPS_FILE;
+    private static String mgmtUsersBackupContent;
+    private static String mgmtGroupsBackupContent;
+
+    public final static String USER_NAME = "testSuite";
+    public final static String RBAC_USER_NAME = "rbacUser";
+    public final static String USERS_PASSWORD = "testSuitePassword";;
+
+    private final static String PASSWORD_HASH = "29a64f8524f32269aa9b681efc347f96";
+    private final static String RBAC_PASSWORD_HASH = "34d289513caf0d8967a6d293f128a5d8";
+    private final static String MGMT_USERS_CONTENT = RBAC_USER_NAME + "=" + RBAC_PASSWORD_HASH + "\n" +
+            USER_NAME + "=" + PASSWORD_HASH + "\n";
+
+    /**
+     * Evaluate path of mgmt-users.properties configuration path
+     */
+    static {
+        String jbossHome;
+        if (Boolean.getBoolean("ts.bootable")) {
+            jbossHome = System.getProperty("install.dir");
+        } else {
+            jbossHome = System.getProperty("jboss.home");
+        }
+        MGMT_USERS_FILE = Path.of(jbossHome, "standalone", "configuration", "mgmt-users.properties");
+        MGMT_GROUPS_FILE = Path.of(jbossHome, "standalone", "configuration", "mgmt-groups.properties");
+    }
+
+    /**
+     * Backup original users and create new management users
+     */
+    public static void setup() throws Exception {
+        mgmtUsersBackupContent = Files.readString(MGMT_USERS_FILE, StandardCharsets.UTF_8);
+        mgmtGroupsBackupContent = Files.readString(MGMT_GROUPS_FILE, StandardCharsets.UTF_8);
+        Files.writeString(MGMT_USERS_FILE, MGMT_USERS_CONTENT, StandardCharsets.UTF_8);
+        Files.writeString(MGMT_GROUPS_FILE, RBAC_USER_NAME + "=Monitor\n", StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Recover original management users
+     */
+    public static void tearDown() throws Exception {
+        if (mgmtUsersBackupContent != null) {
+            Files.writeString(MGMT_USERS_FILE, mgmtUsersBackupContent, StandardCharsets.UTF_8);
+        }
+        if (mgmtGroupsBackupContent != null) {
+            Files.writeString(MGMT_GROUPS_FILE, mgmtGroupsBackupContent, StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/micrometer/src/test/java/org/jboss/eap/qe/micrometer/prometheus/MicrometerPrometheusTestCase.java
+++ b/micrometer/src/test/java/org/jboss/eap/qe/micrometer/prometheus/MicrometerPrometheusTestCase.java
@@ -1,0 +1,278 @@
+package org.jboss.eap.qe.micrometer.prometheus;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClients;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.eap.qe.microprofile.common.setuptasks.MicroProfileTelemetryServerConfiguration;
+import org.jboss.eap.qe.microprofile.common.setuptasks.MicrometerPrometheusSetup;
+import org.jboss.eap.qe.microprofile.common.setuptasks.MicrometerServerConfiguration;
+import org.jboss.eap.qe.microprofile.common.setuptasks.OpenTelemetryServerConfiguration;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianContainerProperties;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.arquillian.ArquillianDescriptorWrapper;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
+import org.jboss.eap.qe.microprofile.tooling.server.log.ModelNodeLogChecker;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClientEngine;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
+
+/**
+ * Test for prometheus micrometer registry.
+ */
+@RunWith(Arquillian.class)
+public class MicrometerPrometheusTestCase {
+    private static OnlineManagementClient client = null;
+    ArquillianContainerProperties server = new ArquillianContainerProperties(
+            ArquillianDescriptorWrapper.getArquillianDescriptor());
+    private static final int GET_LAST_LOGS_COUNT = 40;
+
+    private static boolean serverTypeCheck() {
+        String manifectArtifactId = System.getProperty("channel-manifest.artifactId");
+        // standard distribution
+        return (System.getProperty("ts.bootable") == null && Paths.get(System.getProperty("jboss.home")).getFileName().toString().toLowerCase().contains("eap")) ||
+                // bootable jar distribution
+                (System.getProperty("ts.bootable") != null && manifectArtifactId != null && manifectArtifactId.toLowerCase().contains("eap"));
+    }
+
+    @Before
+    public void testServerTypeCheck() {
+        Assume.assumeTrue(serverTypeCheck());
+    }
+
+    /**
+     * Enable micrometer and prometheus registry before first test execution
+     */
+    @BeforeClass
+    public static void enableMicrometer() throws Exception {
+        if (!serverTypeCheck()) {
+            return;
+        }
+        client = ManagementClientProvider.onlineStandalone();
+        MicrometerServerConfiguration.enableMicrometer(client, null, true);
+        MicrometerPrometheusSetup.enable(client);
+    }
+
+    /**
+     * Disable micrometer and prometheus registry after last test execution
+     */
+    @AfterClass
+    public static void disableMicrometer() throws Exception {
+        if (!serverTypeCheck()) {
+            return;
+        }
+        try {
+            MicrometerServerConfiguration.disableMicrometer(client, true);
+            MicrometerPrometheusSetup.disable(client);
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * Get prometheus metrics from unsecured end-point, check that JVM/System metrics are in the list
+     */
+    @Test
+    public void basicPrometheusTest() throws Exception {
+        assertFalse("There seems to be conflict between micrometer prometheus end-point and some another end-point.",
+                new ModelNodeLogChecker(client, GET_LAST_LOGS_COUNT).logContains("WFLYMMTREXT0015"));
+        String response = fetchPrometheusMetricsRequireStatusCode(false, 200);
+        MatcherAssert.assertThat(response, containsString("jvm_uptime_seconds "));
+        MatcherAssert.assertThat(response, containsString("cpu_available_processors "));
+    }
+
+    /**
+     * Map prometheus output to the end-point that WF Metrics is using. Startup-error is expected.
+     */
+    @Test
+    public void wfMetricsEnabledTest() throws Exception {
+        MicrometerPrometheusSetup.set(client, "/metrics", false);
+        try {
+            assertTrue(
+                    "\"/metrics\" endpoint should be used by WF metrics, but MicroMeter allows to expose its own metrics there",
+                    new ModelNodeLogChecker(client, GET_LAST_LOGS_COUNT).logContains("WFLYDMHTTP0017"));
+        } finally {
+            MicrometerPrometheusSetup.set(client, false);
+        }
+    }
+
+    /**
+     * Test disables WF Metrics, configure prometheus to use same end-point that is by default used by WF-metrics. Checks that
+     * Micrometer metrics are available.
+     */
+    @Test
+    public void wfMetricsDisabledTest() throws Exception {
+        client.execute("/subsystem=metrics:remove");
+        try {
+            client.execute("/extension=org.wildfly.extension.metrics:remove");
+            try {
+                MicrometerPrometheusSetup.set(client, "/metrics", false);
+                try {
+                    String response = fetchPrometheusMetricsRequireStatusCode(false, 200);
+                    MatcherAssert.assertThat(response, containsString("jvm_uptime_seconds "));
+                    MatcherAssert.assertThat(response, containsString("cpu_available_processors "));
+                } finally {
+                    MicrometerPrometheusSetup.set(client, false);
+                }
+            } finally {
+                client.execute("/extension=org.wildfly.extension.metrics:add");
+            }
+        } finally {
+            client.execute(
+                    "/subsystem=metrics:add(exposed-subsystems=[\"*\"], prefix=\"${wildfly.metrics.prefix:jboss}\", security-enabled=false)");
+        }
+    }
+
+    /**
+     * More security checks are in one test method in order to avoid unnecessary reloads.
+     *
+     * Keep prometheus end-point unsecure, try to get metrics with authorization. Metrics should be available.
+     *
+     * Secure end-point, try to get metrics without authorization. Metrics should not be available.
+     *
+     * Keep end-point secure, try to get metrics with authorization. Metrics should be available.
+     */
+    @Test
+    public void securityTest() throws Exception {
+        MgmtUsersSetup.setup();
+        try {
+            // use authentication, although prometheus is not secured yet
+            String response = fetchPrometheusMetricsRequireStatusCode(true, 200);
+            MatcherAssert.assertThat(response, containsString("jvm_uptime_seconds "));
+            MatcherAssert.assertThat(response, containsString("cpu_available_processors "));
+
+            // secure prometheus, but do not use authentication
+            MicrometerPrometheusSetup.set(client, true);
+            try {
+                response = fetchPrometheusMetricsRequireStatusCode(false, 401);
+                MatcherAssert.assertThat(response, containsString("401 - Unauthorized"));
+
+                // keep prometheus secure, use authentication
+                response = fetchPrometheusMetricsRequireStatusCode(true, 200);
+                MatcherAssert.assertThat(response, containsString("jvm_uptime_seconds "));
+                MatcherAssert.assertThat(response, containsString("cpu_available_processors "));
+            } finally {
+                MicrometerPrometheusSetup.set(client, false);
+            }
+        } finally {
+            MgmtUsersSetup.tearDown();
+        }
+    }
+
+    /**
+     * Check that micrometer shows real values of restricted metrics if proper user with proper RBAC role is used
+     */
+    @Test
+    public void rbacTest() throws Exception {
+        MgmtUsersSetup.setup();
+        try {
+            MicrometerPrometheusSetup.set(client, true);
+            try {
+                // Create the Monitor role mapping and associate the group Monitor with it
+                client.execute("/core-service=management/access=authorization/role-mapping=Monitor:add");
+                client.execute(
+                        "/core-service=management/access=authorization/role-mapping=Monitor/include=group-monitors:add(name=Monitor, type=GROUP)");
+                try {
+                    // enable RBAC
+                    client.execute("/core-service=management/access=authorization:write-attribute(name=provider,value=rbac)");
+                    try {
+                        new Administration(client).reload();
+
+                        // get metrics with user without Monitor RBAC role
+                        List<String> response = fetchPrometheusMetricsRequireStatusCode(true, 200).lines()
+                                .collect(Collectors.toList());
+                        MatcherAssert.assertThat(response, Matchers.hasItem(Matchers.allOf(
+                                Matchers.startsWith("io_max_pool_size"),
+                                Matchers.endsWith("0.0"))));
+
+                        // get metrics with user with Monitor RBAC role
+                        response = fetchPrometheusMetricsWithRbacRequireStatusCode(200).lines().collect(Collectors.toList());
+                        MatcherAssert.assertThat(response, Matchers.hasItem(Matchers.allOf(
+                                Matchers.startsWith("io_max_pool_size"),
+                                not(Matchers.endsWith("0.0")))));
+                    } finally {
+                        client.execute(
+                                "/core-service=management/access=authorization:write-attribute(name=provider,value=simple)");
+                    }
+                } finally {
+                    client.execute("/core-service=management/access=authorization/role-mapping=Monitor:remove");
+                }
+            } finally {
+                MicrometerPrometheusSetup.set(client, false);
+            }
+        } finally {
+            MgmtUsersSetup.tearDown();
+        }
+    }
+
+    /**
+     * Check that info about more metrics subsystems are logged if MicroMeter Prometheus and WF-Metrics are enabled.
+     */
+    @Test
+    public void checkLogsAboutMoreMetricsSubsystemsTest() throws Exception {
+        MicroProfileTelemetryServerConfiguration.disableMicroProfileTelemetry(); // make sure that MP Telemetry is disabled
+        OpenTelemetryServerConfiguration.disableOpenTelemetry(); // make sure that OpenTelemetry is disabled
+        assertTrue("There are WF-Metrics and MicroMeter metrics subsystems, there should be 1 warnings.",
+                new ModelNodeLogChecker(client, GET_LAST_LOGS_COUNT).logContains("Additional metrics systems discovered"));
+    }
+
+    private String fetchPrometheusMetricsRequireStatusCode(boolean authenticate, int requiredStatusCode) throws Exception {
+        return fetchPrometheusMetricsRequireStatusCode(authenticate, requiredStatusCode, MgmtUsersSetup.USER_NAME,
+                MgmtUsersSetup.USERS_PASSWORD);
+    }
+
+    private String fetchPrometheusMetricsWithRbacRequireStatusCode(int requiredStatusCode) throws Exception {
+        return fetchPrometheusMetricsRequireStatusCode(true, requiredStatusCode, MgmtUsersSetup.RBAC_USER_NAME,
+                MgmtUsersSetup.USERS_PASSWORD);
+    }
+
+    private String fetchPrometheusMetricsRequireStatusCode(boolean authenticate, int requiredStatusCode, String userName,
+            String password) throws Exception {
+        String url = "http://" + server.getDefaultManagementAddress() + ":" + server.getDefaultManagementPort()
+                + MicrometerPrometheusSetup.getPrometheusContext();
+
+        Client client;
+        if (authenticate) {
+            CredentialsProvider credentials = new BasicCredentialsProvider();
+            credentials.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(userName, password));
+            client = ((ResteasyClientBuilder) ClientBuilder.newBuilder())
+                    .httpEngine(ApacheHttpClientEngine
+                            .create(HttpClients.custom().setDefaultCredentialsProvider(credentials).build()))
+                    .build();
+        } else {
+            client = ClientBuilder.newClient();
+        }
+
+        try (Response response = client.target(url).request().get()) {
+            MatcherAssert.assertThat("Unexpected status of HTTP response", response.getStatus(),
+                    equalTo(requiredStatusCode));
+            return response.readEntity(String.class);
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/microprofile-telemetry/src/test/java/org/jboss/eap/qe/microprofile/telemetry/metrics/namefellow/MoreMetricsImplementationsTest.java
+++ b/microprofile-telemetry/src/test/java/org/jboss/eap/qe/microprofile/telemetry/metrics/namefellow/MoreMetricsImplementationsTest.java
@@ -1,0 +1,94 @@
+package org.jboss.eap.qe.microprofile.telemetry.metrics.namefellow;
+
+import java.nio.file.Paths;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.eap.qe.microprofile.common.setuptasks.MicrometerPrometheusSetup;
+import org.jboss.eap.qe.microprofile.common.setuptasks.MicrometerServerConfiguration;
+import org.jboss.eap.qe.microprofile.telemetry.metrics.MPTelemetryServerSetupTask;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.creaper.ManagementClientProvider;
+import org.jboss.eap.qe.microprofile.tooling.server.configuration.deployment.ConfigurationUtil;
+import org.jboss.eap.qe.microprofile.tooling.server.log.ModelNodeLogChecker;
+import org.jboss.eap.qe.ts.common.docker.junit.DockerRequiredTests;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+
+/**
+ * Check warnings is more metrics subsystems are used.
+ */
+@RunWith(Arquillian.class)
+@Category(DockerRequiredTests.class)
+@ServerSetup(MPTelemetryServerSetupTask.class)
+@Ignore("https://issues.redhat.com/browse/JBEAP-28665 - scenario doesn't work at all on bootable jar and is instable on standard server")
+public class MoreMetricsImplementationsTest {
+    private static OnlineManagementClient client = null;
+    private static final int GET_LAST_LOGS_COUNT = 40;
+
+    private static boolean serverTypeCheck() {
+        String manifectArtifactId = System.getProperty("channel-manifest.artifactId");
+        // standard distribution
+        return (System.getProperty("ts.bootable") == null && Paths.get(System.getProperty("jboss.home")).getFileName().toString().toLowerCase().contains("eap")) ||
+                // bootable jar distribution
+                (System.getProperty("ts.bootable") != null && manifectArtifactId != null && manifectArtifactId.toLowerCase().contains("eap"));
+    }
+
+    @Deployment()
+    public static WebArchive createDeployment1() {
+        String mpConfig = "otel.service.name=MultipleDeploymentsMetricsTest-first-deployment\n"
+                + MultipleDeploymentsMetricsTest.DEFAULT_MP_CONFIG;
+        return ShrinkWrap.create(WebArchive.class, MultipleDeploymentsMetricsTest.PING_ONE_SERVICE + ".war")
+                .addClasses(PingApplication.class, PingOneService.class, PingOneResource.class)
+                .addAsManifestResource(ConfigurationUtil.BEANS_XML_FILE_LOCATION, "beans.xml")
+                .addAsManifestResource(new StringAsset(mpConfig), "microprofile-config.properties");
+
+    }
+
+    @Before
+    public void prepareMicroMeter() throws Exception {
+        if (serverTypeCheck()) {
+            client = ManagementClientProvider.onlineStandalone();
+            MicrometerServerConfiguration.enableMicrometer(client, null, true);
+            MicrometerPrometheusSetup.enable(client);
+        }
+    }
+
+    @After
+    public void disableMicroMeter() throws Exception {
+        try {
+            if (serverTypeCheck()) {
+                MicrometerServerConfiguration.disableMicrometer(client, true);
+                MicrometerPrometheusSetup.disable(client);
+            }
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * Enable all possible metrics subsystems, check that warning/s are printed in logs.
+     */
+    @Test
+    @RunAsClient
+    public void logTest() throws Exception {
+        int metricsSubsystemsCount = serverTypeCheck() ? 3 : 2;
+        ModelNodeLogChecker modelNodeLogChecker = new ModelNodeLogChecker(client, GET_LAST_LOGS_COUNT);
+        MatcherAssert.assertThat(
+                "There are " + metricsSubsystemsCount + " metrics subsystems, there should be " + (metricsSubsystemsCount - 1)
+                        + " warnings.",
+                (int) modelNodeLogChecker.logCounts("Additional metrics systems discovered"),
+                Matchers.is(metricsSubsystemsCount - 1));
+    }
+}

--- a/microprofile-telemetry/src/test/java/org/jboss/eap/qe/microprofile/telemetry/metrics/namefellow/MultipleDeploymentsMetricsTest.java
+++ b/microprofile-telemetry/src/test/java/org/jboss/eap/qe/microprofile/telemetry/metrics/namefellow/MultipleDeploymentsMetricsTest.java
@@ -35,7 +35,7 @@ public class MultipleDeploymentsMetricsTest {
 
     public static final String PING_ONE_SERVICE = "ping-one-service";
     public static final String PING_TWO_SERVICE = "ping-two-service";
-    private static final String DEFAULT_MP_CONFIG = "otel.sdk.disabled=false\n" +
+    public static final String DEFAULT_MP_CONFIG = "otel.sdk.disabled=false\n" +
             "otel.metric.export.interval=100";
 
     @Deployment(name = PING_ONE_SERVICE, order = 1)

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,8 @@
         <channel-manifest.version></channel-manifest.version>
 
         <version.slf4j>2.0.16</version.slf4j>
+        <version.jakarta.ws.rs>4.0.0</version.jakarta.ws.rs>
+        <version.resteasy>6.2.12.Final</version.resteasy>
 
         <!-- Modular JDK JPMS options -->
         <server.jvm.jpms.args>--add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED</server.jvm.jpms.args>
@@ -321,6 +323,16 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${version.slf4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${version.jakarta.ws.rs}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-client</artifactId>
+                <version>${version.resteasy}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/common/setuptasks/MicrometerPrometheusSetup.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/common/setuptasks/MicrometerPrometheusSetup.java
@@ -1,0 +1,87 @@
+package org.jboss.eap.qe.microprofile.common.setuptasks;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.OperationException;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+import org.wildfly.extras.creaper.core.online.operations.Values;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
+
+/**
+ * Utility class enabling and disabling Micrometer Prometheus registry
+ */
+public class MicrometerPrometheusSetup {
+    public static final String DEFAULT_PROMETHEUS_CONTEXT = "/prometheus";
+    private static String prometheusContext = null;
+    public static final Address SYSPROP_PROMETHEUS_CONTEXT = Address.of("system-property",
+            "org.jboss.eap.xp.micrometer.prometheus.context");
+    public static final Address SYSPROP_SECURITY_ENABLED = Address.of("system-property",
+            "org.jboss.eap.xp.micrometer.prometheus.security-enabled");
+
+    /**
+     * Enable prometheus with most used configuration in this testsuite ("/prometheus" end-point with disabled security)
+     *
+     * @param client Creaper client
+     */
+    public static void enable(OnlineManagementClient client) throws IOException, InterruptedException, TimeoutException {
+        Operations ops = new Operations(client);
+        ops.add(SYSPROP_PROMETHEUS_CONTEXT, Values.of("value", DEFAULT_PROMETHEUS_CONTEXT));
+        prometheusContext = DEFAULT_PROMETHEUS_CONTEXT;
+        ops.add(SYSPROP_SECURITY_ENABLED, Values.of("value", "false"));
+        new Administration(client).reload();
+    }
+
+    /**
+     * Enable prometheus registry with custom parameters
+     *
+     * @param client Creaper client
+     * @param context Prometheus end-point
+     * @param security Security enabled/disabled
+     */
+    public static void set(OnlineManagementClient client, String context, boolean security)
+            throws IOException, InterruptedException, TimeoutException {
+        Operations ops = new Operations(client);
+        ops.writeAttribute(SYSPROP_PROMETHEUS_CONTEXT, "value", context);
+        prometheusContext = context;
+        ops.writeAttribute(SYSPROP_SECURITY_ENABLED, "value", security);
+        new Administration(client).reload();
+    }
+
+    /**
+     * Enable prometheus registry with default end-point (/prometheus) and custom security
+     *
+     * @param client Creaper client
+     * @param security Security enabled/disabled
+     */
+    public static void set(OnlineManagementClient client, boolean security)
+            throws IOException, InterruptedException, TimeoutException {
+        set(client, DEFAULT_PROMETHEUS_CONTEXT, security);
+    }
+
+    /**
+     * Disable prometheus
+     *
+     * @param client Creaper client
+     */
+    public static void disable(OnlineManagementClient client)
+            throws IOException, OperationException, InterruptedException, TimeoutException {
+        Operations ops = new Operations(client);
+        if (ops.exists(SYSPROP_PROMETHEUS_CONTEXT)) {
+            ops.remove(SYSPROP_PROMETHEUS_CONTEXT);
+        }
+        if (ops.exists(SYSPROP_SECURITY_ENABLED)) {
+            ops.remove(SYSPROP_SECURITY_ENABLED);
+        }
+        new Administration(client).reload();
+    }
+
+    /**
+     * Get prometheus end-point
+     */
+    public static String getPrometheusContext() {
+        return prometheusContext;
+    }
+}

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/log/LogChecker.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/log/LogChecker.java
@@ -23,4 +23,12 @@ public interface LogChecker {
      */
     boolean logContains(final String subString);
 
+    /**
+     * Perform search in log or its excerpt and find how many lines contains a sub string.
+     *
+     * @param subString a sub string which will be used to perform search among lines
+     * @return count of lines that contains subString
+     */
+    long logCounts(String subString);
+
 }

--- a/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/log/ModelNodeLogChecker.java
+++ b/tooling-server-configuration/src/main/java/org/jboss/eap/qe/microprofile/tooling/server/log/ModelNodeLogChecker.java
@@ -74,6 +74,19 @@ public final class ModelNodeLogChecker implements LogChecker {
         }
     }
 
+    @Override
+    public long logCounts(String subString) {
+        try {
+            return readLogFileFromManagementModel().asList()
+                    .stream()
+                    .map(ModelNode::asString)
+                    .filter(line -> line.contains(subString))
+                    .count();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
     private ModelNode readLogFileFromManagementModel() throws IOException {
         final Operations ops = new Operations(this.client);
 


### PR DESCRIPTION
This PR adds tests for MicroMeter prometheus registry.

**Server**

This doesn't work on upstream non-community server.

**REST assured library**
REST assured authentication doesn't work
```
given()
  .auth().preemptive().basic(MgmtUsersSetup.USER_NAME, MgmtUsersSetup.PASSWORD)
.when()
  .get(url)
.then()...
```
 and I was not able to figure out how to hardcode Apache Client to it, that's the reason why I'm using RESTEasy. Upstream is using Apache directly: https://github.com/wildfly/wildfly/pull/17857/files#diff-074a5e7f4019eac45c8a7be241dee05f64368102fb7a6e3c93cdd92eec9624ffR124

**Default requirements:**
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Link to the passing job is provided
- [x] Code is self-descriptive and/or documented
- [x] Description of the tests scenarios is included (see #46)