### PR TITLE
Fix upstream CI

### DIFF
--- a/.github/workflows/wildfly-it-tests-bootable.yml
+++ b/.github/workflows/wildfly-it-tests-bootable.yml
@@ -14,9 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'windows-latest']
-        java-version: ['17', '21']
-        java-distribution: ['adopt']
+        include:
+          - os: ubuntu-latest
+            java-version: '17'
+            java-distribution: 'adopt'
+          - os: windows-latest
+            java-version: '21'
+            java-distribution: 'adopt'
     steps:
       - name: Checkout eap-microprofile-test-suite
         uses: actions/checkout@v4
@@ -37,5 +41,5 @@ jobs:
         with:
           name: surefire-reports-server-logs-jdk-${{ matrix.java-distribution }}-${{ matrix.java-version }}
           path: |
-            **/target/surefire-reports/*
-            **/standalone/log/*
+            ./*/target/surefire-reports/*
+            ./*/target/jboss-as/standalone/log/*

--- a/.github/workflows/wildfly-it-tests.yml
+++ b/.github/workflows/wildfly-it-tests.yml
@@ -14,9 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'windows-latest']
-        java-version: ['17', '21']
-        java-distribution: ['adopt']
+        include:
+          - os: ubuntu-latest
+            java-version: '21'
+            java-distribution: 'adopt'
+          - os: windows-latest
+            java-version: '17'
+            java-distribution: 'adopt'
     steps:
       - name: Checkout eap-microprofile-test-suite
         uses: actions/checkout@v4
@@ -37,5 +41,5 @@ jobs:
         with:
           name: surefire-reports-server-logs-jdk-${{ matrix.java-distribution }}-${{ matrix.java-version }}
           path: |
-            **/target/surefire-reports/*
-            **/standalone/log/*
+            ./*/target/surefire-reports/*
+            ./*/target/jboss-as/standalone/log/*

--- a/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/DatabaseCrashTest.java
+++ b/microprofile-fault-tolerance/src/test/java/org/jboss/eap/qe/microprofile/fault/tolerance/DatabaseCrashTest.java
@@ -95,12 +95,13 @@ public class DatabaseCrashTest {
     public static void startDatabase() throws Exception {
         // create data dir for postgres database
         postgresDataDir = Files.createTempDir();
-        // This is needed to run on SELinux enabled RHEL 9 Docker hosts, which is where internal runs are executed,
+        // This is needed to run on SELinux enabled
+        // The following command sets permissions to posgresDataDir so any user can write to this folder
+        //    Postgres image uses different user than user that starts this maven
         // otherwise the following error will prevent the container from starting successfully:
         //   mkdir: cannot create directory '/var/lib/pgsql/data/userdata': Permission denied
-        // Will keep working on RHEL 8 Docker hosts as well.
         java.nio.file.Files.setPosixFilePermissions(Path.of(postgresDataDir.toURI()),
-                PosixFilePermissions.fromString("rwxrwxr-x"));
+                PosixFilePermissions.fromString("rwxrwxrwx"));
 
         // https://github.com/sclorg/postgresql-container/tree/generated/13
         postgresDB = new Docker.Builder("postgres", "quay.io/centos7/postgresql-13-centos7:centos7")

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.org.apache.maven.plugins.maven-surefire-plugin>3.0.0-M9</version.org.apache.maven.plugins.maven-surefire-plugin>
 
         <jboss.home>IF-NOT-DEFINED-WILDFLY-WILL-BE-DOWNLOADED-UNZIPPED-AND-USED-AUTOMATICALLY</jboss.home>
-        <maven.test.redirectTestOutputToFile>false</maven.test.redirectTestOutputToFile>
+        <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
         <version.jakarta.platform>10.0.0</version.jakarta.platform>
         <version.org.eclipse.microprofile>7.0</version.org.eclipse.microprofile>
@@ -57,14 +57,14 @@
         <version.io.rest-assured>5.0.1</version.io.rest-assured>
         <version.junit>4.13.1</version.junit>
         <version.org.jboss.arquillian>1.7.2.Final</version.org.jboss.arquillian>
-        <version.org.jboss.wildfly.dist>37.0.1.Final</version.org.jboss.wildfly.dist>
+        <version.org.jboss.wildfly.dist>39.0.1.Final</version.org.jboss.wildfly.dist>
         <version.org.wildfly.arquillian>5.0.1.Final</version.org.wildfly.arquillian>
         <version.org.fusesource.jansi>1.18</version.org.fusesource.jansi>
         <version.io.undertow.undertow-core>2.3.0.Alpha2</version.io.undertow.undertow-core>
         <version.org.jboss.threads.jboss-threads>2.4.0.Final</version.org.jboss.threads.jboss-threads>
         <!-- wildfly-core update needed to have the launcher version with BootableJarCommandBuilder used to start
         the server up -->
-        <version.org.wildfly.core>27.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>31.0.3.Final</version.org.wildfly.core>
         <version.org.wildfly.launcher>1.0.0.Final</version.org.wildfly.launcher>
         <version.org.wildfly.extras.creaper>2.0.3</version.org.wildfly.extras.creaper>
         <version.org.yaml.snakeyaml>1.33</version.org.yaml.snakeyaml>


### PR DESCRIPTION
* TS was using old WF version by default, that doesn't use latest features. This PR updates WF/WF-core versions.
* DatabaseCrashTest
  * https://github.com/jboss-eap-qe/eap-microprofile-test-suite/issues/321
  * Postgres container uses postgres user, which is different user that user that is executing maven. So postgres user can't use data folder shared from java, unless the folder would have permissions for other users (not in owner/owner-group) to write to the folder. Java comment there was talking about "mkdir: cannot create directory '/var/lib/pgsql/data/userdata': Permission denied" error, but this error was caused by permissions, not by SELinux. And doesn't go from setPosixFilePermissions method, but during staring of container. I updated javadoc a little bit.
* Limit github CI to Ubuntu & WF & JDK21, Windows & WF & JDK17, Ubuntu & bootable jar & JDK17, Windows & bootable jar & JDK21. I believe that we don't need 8 combinations for upstream CI, but we still have JDK 17 for both Windows and Ubuntu, JDK 21 for both Windows and Ubuntu, BootableJar for both Windows and Ubuntu and zip server for both Windows and Ubuntu.
* Store logs to files, so we can easily check in web UI, which test is failing
* Fix uploading of surefire artifacts in "actions/upload-artifact@v4" section of upstream CI definition